### PR TITLE
#1590 CSS styles override in preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.0.1",
     "graphql": "^15.3.0",
     "json-edit-react": "^0.9.6",
+    "json-to-css": "^0.1.0",
     "lodash": "^4.17.21",
     "luxon": "^1.27.0",
     "nanoid": "^3.1.22",

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -331,6 +331,7 @@ a:hover {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  background-color: inherit;
 }
 
 // Menu bar links
@@ -2632,12 +2633,13 @@ h6:first-child {
 
   #menu-bar {
     font-size: inherit;
+    background-color: inherit;
     .list {
       z-index: 2000;
       position: absolute;
       top: @mobileHeaderHeight;
       left: 0px;
-      background: @darkGrey;
+      background-color: inherit;
       width: 95%;
       padding: 5px 30px 20px 25px;
     }

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -46,12 +46,7 @@ const UserArea: React.FC = () => {
   if (!currentUser || currentUser?.username === config.nonRegisteredUser) return null
 
   return (
-    <Container
-      id="user-area"
-      fluid
-      // Custom color option (for Angola only currently)
-      style={{ backgroundColor: preferences?.style?.headerBgColor ?? '' }}
-    >
+    <Container id="user-area" fluid>
       <BrandArea />
       <div id="user-area-left">
         <MainMenuBar

--- a/src/contexts/SystemPrefs.tsx
+++ b/src/contexts/SystemPrefs.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 import { LanguageOption } from './Localisation'
 import { getRequest } from '../utils/helpers/fetchMethods'
 import getServerUrl from '../utils/helpers/endpoints/endpointUrlBuilder'
+// @ts-ignore -- no types declarations available
+import Css from 'json-to-css'
 
 interface PrefsState {
   preferences?: {
@@ -46,6 +48,12 @@ export const SystemPrefsProvider = ({ children }: { children: React.ReactNode })
           latestSnapshot,
           loading: false,
         })
+
+        // Install custom CSS into document head
+        if (preferences.style) {
+          const cssString = Css.of(preferences.style)
+          document.head.appendChild(document.createElement('style')).innerHTML = cssString
+        }
       })
       .catch((err) => {
         setPrefsState({ loading: false, error: err })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,6 +5270,11 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json-to-css@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/json-to-css/-/json-to-css-0.1.0.tgz#4b3d104e8ed2c81b8a071eb86953d1936b3a08e6"
+  integrity sha512-0A6Xooey9slodt9MX7wWRVNo5G7fujVlBkdyhjNPg3GzoJW7j5EBD/Duw3zK3V132Ma/HTEnBRchl1PmOWiZgg==
+
 json-to-pretty-yaml@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"


### PR DESCRIPTION
This was quite easy in the end. Just had to figure out how to inject a CSS text string into the head of the document.

You need to run `yarn install` to install one small additional package (see comments).

To get the Angola purple header bar, change the `"style"` value in preferences (Configuration -> System Preferences) to the following actual CSS (instead of our hacky one-off solution)

<img width="283" alt="Screenshot 2023-11-04 at 5 03 29 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/76772055-6065-43ae-9cc5-ef500df3e234">

It'd be good to do something proper with Semantic UI so we could override all the Semantic global variables, but that's quite a bit more complicated, so this will do for now.
