### PR TITLE
#1586 Other header tweaks

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2675,6 +2675,7 @@ h6:first-child {
       margin-right: 10px;
       max-width: 100px;
       height: auto;
+      max-height: 100%;
     }
   }
 

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2658,6 +2658,10 @@ h6:first-child {
   #user-area {
     height: @mobileHeaderHeight;
     padding-left: 10px;
+    .visible.menu .item {
+      font-size: 12px;
+      padding: 0.6em !important;
+    }
   }
 
   #user-area-left {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2659,7 +2659,7 @@ h6:first-child {
     height: @mobileHeaderHeight;
     padding-left: 10px;
     .visible.menu .item {
-      font-size: 12px;
+      font-size: 0.9rem;
       padding: 0.8em !important;
       .dropdown {
         padding: 0 !important;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1137,7 +1137,7 @@ a:hover {
     padding-top: 0 !important;
     @media only screen and (max-width: @largestMobileScreen) {
       .ui.form .field {
-        margin-bottom: 0;
+        margin-bottom: 0.5em;
       }
     }
   }

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2660,7 +2660,10 @@ h6:first-child {
     padding-left: 10px;
     .visible.menu .item {
       font-size: 12px;
-      padding: 0.6em !important;
+      padding: 0.8em !important;
+      .dropdown {
+        padding: 0 !important;
+      }
     }
   }
 

--- a/semantic/src/site/modules/dropdown.overrides
+++ b/semantic/src/site/modules/dropdown.overrides
@@ -5,8 +5,8 @@
 @media only screen and (max-width: @largestMobileScreen) {
   // So that the sub menus show properly in mobile for Header menu
   .ui.dropdown .menu .menu {
-    top: 350% !important;
-    left: 0%;
+    top: 150% !important;
+    left: 40%;
   }
 
   // To give drop-downs a bit more vertical height in mobile

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -409,7 +409,13 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
   if (!orgs.some(({ isSystemOrg }) => isSystemOrg))
     dropdownOptions.push({
       key: LOGIN_AS_NO_ORG,
-      text: `> ${t('LABEL_NO_ORG_SELECT')}`,
+      text: (
+        <span>
+          <em>{t('LABEL_NO_ORG')}</em>
+          <br />
+          <em>{t('LABEL_USER_ONLY')}</em>
+        </span>
+      ) as any,
       value: LOGIN_AS_NO_ORG,
     })
   return (

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -236,7 +236,7 @@ export default {
   LABEL_FILE_UPLOAD_PLACEHOLDER: 'Use the above bar to browse your file system',
   LABEL_FILE_DOWNLOAD_ERROR: 'Error trying to download',
   LABEL_NO_ORG: 'No organisation',
-  LABEL_NO_ORG_SELECT: 'No organisation (act as user only)',
+  LABEL_USER_ONLY: '(Act as user only)',
   LABEL_NO_ORG_OPTION: 'Log in without organisation',
   LABEL_PROCESSING: 'Processing...',
   LABEL_PREVIOUS_REVIEW: 'Previous review',


### PR DESCRIPTION
Fix #1586 

Main purpose is to fix the overly wide organisation menu, from this:
![Screenshot 2023-11-06 at 3 55 59 PM](https://github.com/openmsupply/conforma-web-app/assets/5456533/eda69fef-95d6-43f8-a9e1-f1d875d9b56a)

to this:
![Screenshot 2023-11-06 at 3 56 22 PM](https://github.com/openmsupply/conforma-web-app/assets/5456533/5496b70b-3781-4e80-a72e-cff0f6fb2589)

So I also dropped the text and item size down a bit (as listed in #1579)
