### PR TITLE
#1075 Links in Help menu

### DIFF
--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -93,6 +93,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
     intRefDocs: { active: false },
     extRefDocs: { active: false },
   })
+  const { preferences } = usePrefs()
   const { push, pathname } = useRouter()
   const {
     userState: { currentUser },
@@ -120,6 +121,8 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
 
   const getTemplateSubmenu = (template: TemplateInList) =>
     template.templateCategory.isSubmenu ? template.templateCategory.title : null
+
+  const helpLinks = preferences?.helpLinks ?? []
 
   const applicationListOptions = constructNestedMenuOptions(templates, {
     filterMethod: ({ templateCategory: { uiLocation } }) => uiLocation.includes(UiLocation.List),
@@ -275,10 +278,13 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
             />
           </List.Item>
         )}
-        {extReferenceDocs.length && (
+        {helpLinks.length + extReferenceDocs.length > 0 && (
           <List.Item className={dropdownsState.extRefDocs.active ? 'selected-link' : ''}>
             <Dropdown text={t('MENU_ITEM_HELP')}>
               <Dropdown.Menu>
+                {helpLinks.map(({ text, link }) => (
+                  <Dropdown.Item key={link} onClick={() => window.open(link)} text={text} />
+                ))}
                 {extReferenceDocs.map((doc) => (
                   <Dropdown.Item
                     key={doc.uniqueId}

--- a/src/contexts/SystemPrefs.tsx
+++ b/src/contexts/SystemPrefs.tsx
@@ -14,6 +14,7 @@ interface PrefsState {
     googleAnalyticsId?: string
     siteHost?: string
     style?: { headerBgColor?: string }
+    helpLinks?: { text: string; link: string }[]
   }
   languageOptions?: LanguageOption[]
   latestSnapshot?: string


### PR DESCRIPTION
Fix #1596 

Just a quick little addition (for @LaurenceHolding) to allow displaying links in the Help menu. (I've added documentation to the "Preferences" page in back-end.

To test, just add a new property called `"helpLinks"` in preferences -> web, with an array of links, like so:
```
[
  {
    "text": "Conforma Docs",
    "link": "https://docs.conforma.nz/docs/about/introduction/"
  }
]
```