### PR TITLE
#1604+ Tab fix

### DIFF
--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -54,12 +54,14 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
   } = fullStructure
 
   const getTabFromQuery = (tabQuery: string | undefined) => {
-    const index = tabIdentifiers.findIndex((tabName) => tabName === tabQuery)
+    const tabIds = isMobile ? [...tabIdentifiers].reverse() : tabIdentifiers
+    const index = tabIds.findIndex((tabName) => tabName === tabQuery)
     return index === -1 ? 0 : index
   }
 
   const handleTabChange = (_: SyntheticEvent, data: StrictTabProps) => {
-    updateQuery({ tab: tabIdentifiers[data.activeIndex as number] })
+    const tabIndex = data.activeIndex as number
+    updateQuery({ tab: tabIdentifiers[isMobile ? tabIdentifiers.length - 1 - tabIndex : tabIndex] })
   }
 
   const tabPanes = [
@@ -97,6 +99,8 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
     },
   ]
 
+  if (isMobile) tabPanes.reverse()
+
   return (
     <Container id="review-area">
       <Switch>
@@ -110,7 +114,7 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
             {!isMobile && <ReviewProgress structure={structure} />}
             <div id="review-tabs">
               <Tab
-                panes={isMobile ? tabPanes.reverse() : tabPanes}
+                panes={tabPanes}
                 onTabChange={handleTabChange}
                 activeIndex={getTabFromQuery(tab)}
               />
@@ -151,11 +155,7 @@ const ReviewHomeHeader: React.FC<ReviewHomeProps> = ({
   // re-renders
   const [prevQueryString] = useState(location?.state?.prevQuery)
 
-  if (!tab) {
-    !isMobile
-      ? updateQuery({ tab: tabIdentifiers[0] })
-      : updateQuery({ tab: tabIdentifiers[tabIdentifiers.length - 1] })
-  }
+  if (!tab) updateQuery({ tab: tabIdentifiers[0] })
 
   const linkBack = prevQueryString
     ? `/applications${prevQueryString}`


### PR DESCRIPTION
Hey @guatemartin , ignore this if you've already done it, but this just fixes the tab linking problem picked up in your last PR.

Went back to source, and reversed the tab panes definitions themselves (and removed the other reversals we've added). Then just updated the `get` and `update` query methods to invert the indexing. 

If you've already fixed it, just close this PR. Otherwise merge this into yours and then merge #1608 . Cheers.