### PR TITLE
#1623 Input validation for Search element

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -605,6 +605,7 @@ Once selected, items are displayed in a "card" view:
 - **icon**: `string` -- the name of the icon shown in the search box, from Semantic-UI icons. (default: "search" : 🔍 )
 - **multiSelect**: `boolean` -- whether or not the user can select multiple items for their response (default: `false`)
 - **minCharacters**: `number` -- the minimum number of characters the user must type before the search query executes (default: 1). This is useful in situations where need the user to look up a specific item without being able to freely browse through the entire results list. For example, to look up organisation in our system using "registration" code, we set `minCharacters = 6`, so the user will need to know an exact code rather than being able to try characters one at a time.
+- **restrictCase**: `"upper" | "lower"` -- if specified, all user input will be automatically converted to the specified text case.
 - **displayFormat**: `object` -- defines how to display the search results and the user's selection cards. See `displayFormat` for the [List Builder](#list-builder) (above) for detailed explanation. In this case, however, instead of a `code` substitution, the display string should contain property names from the result object. For example:
   ```
   displayFormat: {
@@ -619,6 +620,9 @@ Once selected, items are displayed in a "card" view:
 - **resultFormat**: `object` -- same as `displayFormat`, but used when specifying a format for the "result" display that is different to the selection card display. If not specified, `resultFormat` will just be the same as `displayFormat`.
   Note that for the "result" display, only the `title` and `description` fields are used (`subtitle` is not shown).
 - **textFormat** `string` -- a formatting substitution string like the above, to be generate the "text" value in the response. Note: currently the only place this text value is ever seen by the user is if it's used inside a listBuilder table (optional)
+- **inputPattern**: `string (regex)` -- if specified, the user search input must conform to this Regex pattern. For example `^[0-9]{9}[A-Z]{2}[0-9]{3}$` would require user to enter 9 digits followed by 2 uppercase letters, then 3 more digits. If the user deviates from this, an error message will be displayed.
+- **inputExample**: `string` -- one problem with the above `inputPattern` is that we need to make sure that we don't show an input error while the user is in the process of entering text, even though their partial input (probably) won't yet comply with the required pattern. As a workaround for this, we supply an `inputExample` here, which is a valid example that matches the pattern. For the above example pattern, a valid value could be `"123456789XY666"`. The element then internally uses a combination of the user input this example to validate against the regex pattern.
+- **inputErrorMessage**: `string` -- if user input doesn't match the specified `inputPattern` this message will displayed as the error. If not provided, we use a generic default ("Invalid input pattern").
 
 #### Response type
 

--- a/src/formElementPlugins/search/localisation.json
+++ b/src/formElementPlugins/search/localisation.json
@@ -1,5 +1,7 @@
 {
   "MESSAGE_NO_RESULTS": "Nothing found",
   "DEFAULT_PLACEHOLDER": "Search...",
-  "MESSAGE_LOADING": "Loading..."
+  "MESSAGE_LOADING": "Loading...",
+  "INPUT_ERROR": "Invalid input pattern",
+  "VALIDATION_ERROR": "Invalid or missing selection"
 }

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -412,6 +412,9 @@ const getDefaultString = (
   }
 }
 
+// In order to check that user input is consistent with regex pattern, even when
+// it's only partially completed (and therefore won't match the regex), we
+// combine it with a known correct example and then test it against the pattern.
 const partialMatch = (text: string, example: string, pattern?: RegExp) => {
   if (!pattern) return true
   const fullString = text + example.slice(text.length)

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -12,12 +12,30 @@ import useDebounce from './useDebounce'
 import './styles.css'
 import useDefault from '../../useDefault'
 import functions from '../../../containers/TemplateBuilder/evaluatorGui/evaluatorFunctions'
+import { partialMatch } from './partialMatch'
+import { EvaluatorNode } from '../../../utils/types'
+import { SemanticICONS } from 'semantic-ui-react/dist/commonjs/generic'
 
 interface DisplayFormat {
   title?: string
   subtitle?: string
   description?: string
   simple?: boolean
+}
+
+interface SearchParameters {
+  label?: string
+  description?: string
+  placeholder: string
+  source: EvaluatorNode
+  icon: SemanticICONS
+  multiSelect: boolean
+  minCharacters: number
+  displayFormat: { title: string; subtitle: string; description: string }
+  resultFormat: { title: string; description: string }
+  textFormat: string
+  displayType: 'card' | 'list' | 'input'
+  default: Response | Response[]
 }
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
@@ -40,12 +58,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     icon = 'search',
     multiSelect = false,
     minCharacters = 1,
-    displayFormat = {},
+    displayFormat = { title: '', subtitle: '', description: '' },
     resultFormat = displayFormat,
     textFormat,
     displayType = 'card',
     default: defaultValue,
-  } = parameters
+  } = parameters as SearchParameters
 
   const {
     userState: { currentUser },
@@ -135,6 +153,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     if (displayType === 'input') setSelection([])
 
     const text = e.target.value
+    console.log('Match?', partialMatch(/[0-9]{9}[A-Z]{2}[0-9]{3}/, text))
+
     setSearchText(text)
     if (text.length < minCharacters) return
     setDebounceInput(text.trim())

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -63,7 +63,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     minCharacters = 1,
     restrictCase,
     inputPattern,
-    inputExample,
+    inputExample = 'a',
     inputErrorMessage = t('INPUT_ERROR'),
     displayFormat = { title: '', subtitle: '', description: '' },
     resultFormat = displayFormat,
@@ -167,7 +167,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     if (restrictCase === 'upper') text = text.toUpperCase()
     if (restrictCase === 'lower') text = text.toUpperCase()
 
-    const inputValid = partialMatch(text, inputRegex, inputExample)
+    const inputValid = partialMatch(text, inputExample, inputRegex)
 
     if (!inputValid) {
       setInputError(true)
@@ -191,6 +191,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         ? substituteValues(displayFormat.title ?? displayFormat.description, selectedResult)
         : ''
     )
+    setInputError(false)
   }
 
   const handleFocus = (e: any) => {
@@ -258,7 +259,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           onFocus={handleFocus}
           onSearchChange={handleChange}
           onResultSelect={handleSelect}
-          minCharacters={minCharacters}
+          // This prevents the "results" list appearing when in an error state
+          minCharacters={isError ? Infinity : minCharacters}
           placeholder={placeholder}
           results={
             loading ? [{ title: t('MESSAGE_LOADING') }] : createResultsArray(results, resultFormat)
@@ -407,8 +409,8 @@ const getDefaultString = (
   }
 }
 
-const partialMatch = (text: string, pattern?: RegExp, example?: string) => {
-  if (!pattern || !example) return true
+const partialMatch = (text: string, example: string, pattern?: RegExp) => {
+  if (!pattern) return true
   const fullString = text + example.slice(text.length)
   console.log(fullString)
 

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -98,6 +98,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       : []
   )
   const [inputError, setInputError] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
   const { isEditable } = element
 
   const [debounceOutput, setDebounceInput] = useDebounce<string>('', DEBOUNCE_TIMEOUT)
@@ -195,6 +196,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   }
 
   const handleFocus = (e: any) => {
+    setIsFocused(true)
     // This makes the component perform a new search when re-focusing (if no
     // selection already), as changes in other elements may have changed some of
     // the dynamic parameters in this element
@@ -259,8 +261,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           onFocus={handleFocus}
           onSearchChange={handleChange}
           onResultSelect={handleSelect}
-          // This prevents the "results" list appearing when in an error state
-          minCharacters={isError ? Infinity : minCharacters}
+          minCharacters={minCharacters}
           placeholder={placeholder}
           results={
             loading ? [{ title: t('MESSAGE_LOADING') }] : createResultsArray(results, resultFormat)
@@ -268,6 +269,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           disabled={!isEditable}
           input={{ icon, iconPosition: 'left' }}
           noResultsMessage={t('MESSAGE_NO_RESULTS')}
+          onBlur={() => setIsFocused(false)}
+          open={isFocused && !inputError && searchText.length >= minCharacters && !loading}
         />
         {!errorMessage ? null : <Label pointing prompt content={errorMessage} />}
       </Form.Field>
@@ -412,7 +415,6 @@ const getDefaultString = (
 const partialMatch = (text: string, example: string, pattern?: RegExp) => {
   if (!pattern) return true
   const fullString = text + example.slice(text.length)
-  console.log(fullString)
 
   return pattern.test(fullString)
 }


### PR DESCRIPTION
Fix #1623 

4 new parameters (all optional) for the Search element:

- `inputPattern`
- `inputExample`
- `inputErrorMessage`
- `restrictCase`

See updated docs for specifics.

Also, a bit of improvement to existing functionality.