### PR TITLE
#1103B Memoise list actions etc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 registry=https://registry.npmjs.org
-@openmsupply:registry=https://npm.pkg.github.com
+@msupply-foundation:registry=https://npm.pkg.github.com

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -177,19 +177,18 @@ const FilterComponent: React.FC<{
       filter: gqlFilter,
       userId,
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   })
 
   const appCount = data?.applicationList?.totalCount
 
   useEffect(() => {
-    if (!loading && appCount !== undefined)
-      setReadyFilters((prev) => ({ ...prev, [filter.code]: appCount }))
-  }, [loading])
+    if (appCount !== undefined) setReadyFilters((prev) => ({ ...prev, [filter.code]: appCount }))
+  }, [loading, appCount])
 
   if (error) return <span className="error-colour">{t('ERROR_LOADING_FILTER')}</span>
 
-  if (loading || !appCount) return null
+  if (!appCount) return null
 
   return (
     <Link

--- a/src/containers/List/ListFilters/OptionFilters.tsx
+++ b/src/containers/List/ListFilters/OptionFilters.tsx
@@ -4,6 +4,7 @@ import { Dropdown, Input } from 'semantic-ui-react'
 import { EnumFilterProps, StaticListFilterProps, SearchableListFilterProps } from './types'
 import { FilterContainer, FilterOptions, FilterTitle } from './common'
 import { useLanguageProvider } from '../../../contexts/Localisation'
+import useDebounce from '../../../formElementPlugins/search/src/useDebounce'
 
 const EnumFilter: React.FC<EnumFilterProps> = ({
   getActiveOptions,
@@ -44,7 +45,7 @@ const StaticListFilter: React.FC<StaticListFilterProps> = ({
   const { query, resultExtractor, variables } = getFilterListQuery({ filterListParameters })
 
   const { data, error } = useQuery(query, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
     variables,
   })
 
@@ -75,7 +76,7 @@ const SearchableListFilter: React.FC<SearchableListFilterProps> = ({
   onRemove,
 }) => {
   const { t } = useLanguageProvider()
-  const [searchValue, setSearchValue] = useState('')
+  const [searchValue, setSearchValue] = useDebounce('')
 
   const { query, resultExtractor, variables } = getFilterListQuery({
     searchValue,
@@ -83,7 +84,7 @@ const SearchableListFilter: React.FC<SearchableListFilterProps> = ({
   })
 
   const { data, error } = useQuery(query, {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
     variables,
   })
   const activeOptions = getActiveOptions()

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -218,7 +218,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       }
     if (isChangeRequest && !isChanged)
       return { extraClasses: 'changes change-request-unchanged', iconName: 'exclamation circle' }
-    // Updated withouth change request
+    // Updated without change request
     if (isChanged) return { extraClasses: 'changes updated', iconName: 'info circle' }
     return
   }

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -38,23 +38,27 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = ({
   )
 
   useEffect(() => {
-    // Update dynamic parameters when responses change
-    const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
-    Object.entries(parameterExpressions).forEach(([field, expression]) => {
-      evaluateExpression(expression as EvaluatorNode, {
-        objects: {
-          responses: { ...allResponses, thisResponse: response?.text },
-          currentUser,
-          applicationData,
-          functions,
-        },
-        APIfetch: fetch,
-        graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
-        headers: { Authorization: 'Bearer ' + JWT },
-      }).then((result: any) =>
-        setEvaluatedParameters((prevState) => ({ ...prevState, [field]: result }))
-      )
-    })
+    // Update dynamic parameters when responses change, but only if there's no
+    // saved evaluations (usually INFORMATION type), or "showLiveParameters" has
+    // been explicitly set
+    if (simpleParameters?.showLiveParameters || !response?.evaluatedParameters) {
+      const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
+      Object.entries(parameterExpressions).forEach(([field, expression]) => {
+        evaluateExpression(expression as EvaluatorNode, {
+          objects: {
+            responses: { ...allResponses, thisResponse: response?.text },
+            currentUser,
+            applicationData,
+            functions,
+          },
+          APIfetch: fetch,
+          graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
+          headers: { Authorization: 'Bearer ' + JWT },
+        }).then((result: any) =>
+          setEvaluatedParameters((prevState) => ({ ...prevState, [field]: result }))
+        )
+      })
+    }
   }, [allResponses])
 
   if (!pluginCode || !isVisible) return null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,7 +66,7 @@ const App: React.FC = () => {
       // Maximum size of cache to persist (in bytes).
       // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
       // If exceeded, persistence will pause and app will start up cold on next launch.
-      maxSize: false,
+      // maxSize: false,
 
       /**
        * Debugging options.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { LanguageOption, LanguageProvider } from './contexts/Localisation'
 import { ToastProvider } from './contexts/Toast/ToastProvider'
 import { SystemPrefsProvider } from './contexts/SystemPrefs'
 import { usePrefs } from './contexts/SystemPrefs'
-// import { persistCache } from 'apollo3-cache-persist'
+import { persistCache } from 'apollo3-cache-persist'
 import { Loading } from './components'
 import getServerUrl from './utils/helpers/endpoints/endpointUrlBuilder'
 
@@ -57,27 +57,27 @@ const App: React.FC = () => {
     })
     setClient(client)
 
-    // persistCache({
-    //   cache,
-    //   storage: window.localStorage,
-    //   /**
-    //    * Storage options.
-    //    */
-    //   // Maximum size of cache to persist (in bytes).
-    //   // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
-    //   // If exceeded, persistence will pause and app will start up cold on next launch.
-    //   maxSize: false,
+    persistCache({
+      cache,
+      storage: window.localStorage,
+      /**
+       * Storage options.
+       */
+      // Maximum size of cache to persist (in bytes).
+      // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
+      // If exceeded, persistence will pause and app will start up cold on next launch.
+      maxSize: false,
 
-    //   /**
-    //    * Debugging options.
-    //    */
-    //   // Enable console logging.
-    //   // debug: boolean,
-    // }).then(() => {
-    //   // TODO: Check when this would run!
-    //   client.onResetStore(async () => cache.reset())
-    //   setClient(client)
-    // })
+      /**
+       * Debugging options.
+       */
+      // Enable console logging.
+      // debug: boolean,
+    }).then(() => {
+      // TODO: Check when this would run!
+      client.onResetStore(async () => cache.reset())
+      setClient(client)
+    })
     return () => {}
   }, [])
 

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -49,6 +49,8 @@ export type Query = Node & {
   applicationNotes?: Maybe<ApplicationNotesConnection>;
   /** Reads and enables pagination through a set of `ApplicationResponse`. */
   applicationResponses?: Maybe<ApplicationResponsesConnection>;
+  /** Reads and enables pagination through a set of `ApplicationReviewerAction`. */
+  applicationReviewerActions?: Maybe<ApplicationReviewerActionsConnection>;
   /** Reads and enables pagination through a set of `ApplicationStageHistory`. */
   applicationStageHistories?: Maybe<ApplicationStageHistoriesConnection>;
   /** Reads and enables pagination through a set of `ApplicationStageStatusAll`. */
@@ -67,8 +69,6 @@ export type Query = Node & {
   dataChangelogs?: Maybe<DataChangelogsConnection>;
   /** Reads and enables pagination through a set of `DataTable`. */
   dataTables?: Maybe<DataTablesConnection>;
-  /** Reads and enables pagination through a set of `DataTableManufacturingStep`. */
-  dataTableManufacturingSteps?: Maybe<DataTableManufacturingStepsConnection>;
   /** Reads and enables pagination through a set of `DataTableActiveIngredient`. */
   dataTableActiveIngredients?: Maybe<DataTableActiveIngredientsConnection>;
   /** Reads and enables pagination through a set of `DataTableAdministrationRoute`. */
@@ -79,32 +79,48 @@ export type Query = Node & {
   dataTableAnnex2s?: Maybe<DataTableAnnex2sConnection>;
   /** Reads and enables pagination through a set of `DataTableAtcCode`. */
   dataTableAtcCodes?: Maybe<DataTableAtcCodesConnection>;
-  /** Reads and enables pagination through a set of `DataTableAtcTherapeuticCategory`. */
-  dataTableAtcTherapeuticCategories?: Maybe<DataTableAtcTherapeuticCategoriesConnection>;
   /** Reads and enables pagination through a set of `DataTableContainer`. */
   dataTableContainers?: Maybe<DataTableContainersConnection>;
   /** Reads and enables pagination through a set of `DataTableCountry`. */
   dataTableCountries?: Maybe<DataTableCountriesConnection>;
   /** Reads and enables pagination through a set of `DataTableDosageForm`. */
   dataTableDosageForms?: Maybe<DataTableDosageFormsConnection>;
+  /** Reads and enables pagination through a set of `DataTableDosageFormGroup`. */
+  dataTableDosageFormGroups?: Maybe<DataTableDosageFormGroupsConnection>;
   /** Reads and enables pagination through a set of `DataTableGenericIngredient`. */
   dataTableGenericIngredients?: Maybe<DataTableGenericIngredientsConnection>;
-  /** Reads and enables pagination through a set of `DataTableIngredientsList`. */
-  dataTableIngredientsLists?: Maybe<DataTableIngredientsListsConnection>;
-  /** Reads and enables pagination through a set of `DataTableInternationalDiallingPrefix`. */
-  dataTableInternationalDiallingPrefixes?: Maybe<DataTableInternationalDiallingPrefixesConnection>;
   /** Reads and enables pagination through a set of `DataTableListOfSra`. */
   dataTableListOfSras?: Maybe<DataTableListOfSrasConnection>;
-  /** Reads and enables pagination through a set of `DataTableManufacturingStepsSimpler`. */
-  dataTableManufacturingStepsSimplers?: Maybe<DataTableManufacturingStepsSimplersConnection>;
+  /** Reads and enables pagination through a set of `DataTableManufacturer`. */
+  dataTableManufacturers?: Maybe<DataTableManufacturersConnection>;
+  /** Reads and enables pagination through a set of `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturerApplicationJoins?: Maybe<DataTableManufacturerApplicationJoinsConnection>;
+  /** Reads and enables pagination through a set of `DataTableManufacturerRepresentative`. */
+  dataTableManufacturerRepresentatives?: Maybe<DataTableManufacturerRepresentativesConnection>;
+  /** Reads and enables pagination through a set of `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentativeApplicationJoins?: Maybe<DataTableManufacturerRepresentativeApplicationJoinsConnection>;
+  /** Reads and enables pagination through a set of `DataTablePermitChemical`. */
+  dataTablePermitChemicals?: Maybe<DataTablePermitChemicalsConnection>;
+  /** Reads and enables pagination through a set of `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemicalApplicationJoins?: Maybe<DataTablePermitChemicalApplicationJoinsConnection>;
+  /** Reads and enables pagination through a set of `DataTablePreRegisteredProductsProvisional`. */
+  dataTablePreRegisteredProductsProvisionals?: Maybe<DataTablePreRegisteredProductsProvisionalsConnection>;
+  /** Reads and enables pagination through a set of `DataTablePrequalManufacturer`. */
+  dataTablePrequalManufacturers?: Maybe<DataTablePrequalManufacturersConnection>;
+  /** Reads and enables pagination through a set of `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturerApplicationJoins?: Maybe<DataTablePrequalManufacturerApplicationJoinsConnection>;
   /** Reads and enables pagination through a set of `DataTableProcessingStep`. */
   dataTableProcessingSteps?: Maybe<DataTableProcessingStepsConnection>;
   /** Reads and enables pagination through a set of `DataTableProduct`. */
   dataTableProducts?: Maybe<DataTableProductsConnection>;
   /** Reads and enables pagination through a set of `DataTableProductApplicationJoin`. */
   dataTableProductApplicationJoins?: Maybe<DataTableProductApplicationJoinsConnection>;
-  /** Reads and enables pagination through a set of `DataTableProvince`. */
-  dataTableProvinces?: Maybe<DataTableProvincesConnection>;
+  /** Reads and enables pagination through a set of `DataTableProvisionalProduct`. */
+  dataTableProvisionalProducts?: Maybe<DataTableProvisionalProductsConnection>;
+  /** Reads and enables pagination through a set of `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProductApplicationJoins?: Maybe<DataTableProvisionalProductApplicationJoinsConnection>;
+  /** Reads and enables pagination through a set of `DataTableScheduledChemical`. */
+  dataTableScheduledChemicals?: Maybe<DataTableScheduledChemicalsConnection>;
   /** Reads and enables pagination through a set of `DataTableStorageCondition`. */
   dataTableStorageConditions?: Maybe<DataTableStorageConditionsConnection>;
   /** Reads and enables pagination through a set of `DataTableStorageConditionsSimplified`. */
@@ -121,6 +137,8 @@ export type Query = Node & {
   files?: Maybe<FilesConnection>;
   /** Reads and enables pagination through a set of `Filter`. */
   filters?: Maybe<FiltersConnection>;
+  /** Reads and enables pagination through a set of `GrafanaDashboardImage`. */
+  grafanaDashboardImages?: Maybe<GrafanaDashboardImagesConnection>;
   /** Reads and enables pagination through a set of `Notification`. */
   notifications?: Maybe<NotificationsConnection>;
   /** Reads and enables pagination through a set of `Organisation`. */
@@ -139,8 +157,6 @@ export type Query = Node & {
   permissionsAlls?: Maybe<PermissionsAllsConnection>;
   /** Reads and enables pagination through a set of `PostgresRowLevel`. */
   postgresRowLevels?: Maybe<PostgresRowLevelsConnection>;
-  /** Reads and enables pagination through a set of `ProductApplicationJoin`. */
-  productApplicationJoins?: Maybe<ProductApplicationJoinsConnection>;
   /** Reads and enables pagination through a set of `Review`. */
   reviews?: Maybe<ReviewsConnection>;
   /** Reads and enables pagination through a set of `ReviewAssignment`. */
@@ -191,8 +207,6 @@ export type Query = Node & {
   userOrgJoins?: Maybe<UserOrgJoinsConnection>;
   /** Reads and enables pagination through a set of `UserOrganisation`. */
   userOrganisations?: Maybe<UserOrganisationsConnection>;
-  /** Reads and enables pagination through a set of `UserOrganisationApplicationJoin`. */
-  userOrganisationApplicationJoins?: Maybe<UserOrganisationApplicationJoinsConnection>;
   /** Reads and enables pagination through a set of `Verification`. */
   verifications?: Maybe<VerificationsConnection>;
   actionPlugin?: Maybe<ActionPlugin>;
@@ -204,6 +218,8 @@ export type Query = Node & {
   applicationByOutcomeRegistration?: Maybe<Application>;
   applicationNote?: Maybe<ApplicationNote>;
   applicationResponse?: Maybe<ApplicationResponse>;
+  applicationReviewerAction?: Maybe<ApplicationReviewerAction>;
+  applicationReviewerActionByUserIdAndApplicationId?: Maybe<ApplicationReviewerAction>;
   applicationStageHistory?: Maybe<ApplicationStageHistory>;
   applicationStatusHistory?: Maybe<ApplicationStatusHistory>;
   counter?: Maybe<Counter>;
@@ -211,25 +227,32 @@ export type Query = Node & {
   dataChangelog?: Maybe<DataChangelog>;
   dataTable?: Maybe<DataTable>;
   dataTableByTableName?: Maybe<DataTable>;
-  dataTableManufacturingStep?: Maybe<DataTableManufacturingStep>;
   dataTableActiveIngredient?: Maybe<DataTableActiveIngredient>;
   dataTableAdministrationRoute?: Maybe<DataTableAdministrationRoute>;
   dataTableAnnex?: Maybe<DataTableAnnex>;
   dataTableAnnex2?: Maybe<DataTableAnnex2>;
   dataTableAtcCode?: Maybe<DataTableAtcCode>;
-  dataTableAtcTherapeuticCategory?: Maybe<DataTableAtcTherapeuticCategory>;
   dataTableContainer?: Maybe<DataTableContainer>;
   dataTableCountry?: Maybe<DataTableCountry>;
   dataTableDosageForm?: Maybe<DataTableDosageForm>;
+  dataTableDosageFormGroup?: Maybe<DataTableDosageFormGroup>;
   dataTableGenericIngredient?: Maybe<DataTableGenericIngredient>;
-  dataTableIngredientsList?: Maybe<DataTableIngredientsList>;
-  dataTableInternationalDiallingPrefix?: Maybe<DataTableInternationalDiallingPrefix>;
   dataTableListOfSra?: Maybe<DataTableListOfSra>;
-  dataTableManufacturingStepsSimpler?: Maybe<DataTableManufacturingStepsSimpler>;
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+  dataTableManufacturerApplicationJoin?: Maybe<DataTableManufacturerApplicationJoin>;
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  dataTableManufacturerRepresentativeApplicationJoin?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  dataTablePermitChemicalApplicationJoin?: Maybe<DataTablePermitChemicalApplicationJoin>;
+  dataTablePreRegisteredProductsProvisional?: Maybe<DataTablePreRegisteredProductsProvisional>;
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  dataTablePrequalManufacturerApplicationJoin?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
   dataTableProcessingStep?: Maybe<DataTableProcessingStep>;
   dataTableProduct?: Maybe<DataTableProduct>;
   dataTableProductApplicationJoin?: Maybe<DataTableProductApplicationJoin>;
-  dataTableProvince?: Maybe<DataTableProvince>;
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
+  dataTableProvisionalProductApplicationJoin?: Maybe<DataTableProvisionalProductApplicationJoin>;
+  dataTableScheduledChemical?: Maybe<DataTableScheduledChemical>;
   dataTableStorageCondition?: Maybe<DataTableStorageCondition>;
   dataTableStorageConditionsSimplified?: Maybe<DataTableStorageConditionsSimplified>;
   dataTableUnitsOfProportion?: Maybe<DataTableUnitsOfProportion>;
@@ -242,6 +265,7 @@ export type Query = Node & {
   fileByUniqueId?: Maybe<File>;
   filter?: Maybe<Filter>;
   filterByCode?: Maybe<Filter>;
+  grafanaDashboardImage?: Maybe<GrafanaDashboardImage>;
   notification?: Maybe<Notification>;
   organisation?: Maybe<Organisation>;
   organisationByName?: Maybe<Organisation>;
@@ -252,7 +276,6 @@ export type Query = Node & {
   permissionNameByName?: Maybe<PermissionName>;
   permissionPolicy?: Maybe<PermissionPolicy>;
   permissionPolicyByName?: Maybe<PermissionPolicy>;
-  productApplicationJoin?: Maybe<ProductApplicationJoin>;
   review?: Maybe<Review>;
   reviewByReviewAssignmentId?: Maybe<Review>;
   reviewAssignment?: Maybe<ReviewAssignment>;
@@ -280,8 +303,6 @@ export type Query = Node & {
   userByUsername?: Maybe<User>;
   userApplicationJoin?: Maybe<UserApplicationJoin>;
   userOrganisation?: Maybe<UserOrganisation>;
-  userOrganisationByUserIdAndOrganisationId?: Maybe<UserOrganisation>;
-  userOrganisationApplicationJoin?: Maybe<UserOrganisationApplicationJoin>;
   verification?: Maybe<Verification>;
   verificationByUniqueId?: Maybe<Verification>;
   /** Reads and enables pagination through a set of `AllowedSelfAssignableSectionsShape`. */
@@ -319,6 +340,8 @@ export type Query = Node & {
   applicationNoteByNodeId?: Maybe<ApplicationNote>;
   /** Reads a single `ApplicationResponse` using its globally unique `ID`. */
   applicationResponseByNodeId?: Maybe<ApplicationResponse>;
+  /** Reads a single `ApplicationReviewerAction` using its globally unique `ID`. */
+  applicationReviewerActionByNodeId?: Maybe<ApplicationReviewerAction>;
   /** Reads a single `ApplicationStageHistory` using its globally unique `ID`. */
   applicationStageHistoryByNodeId?: Maybe<ApplicationStageHistory>;
   /** Reads a single `ApplicationStatusHistory` using its globally unique `ID`. */
@@ -329,8 +352,6 @@ export type Query = Node & {
   dataChangelogByNodeId?: Maybe<DataChangelog>;
   /** Reads a single `DataTable` using its globally unique `ID`. */
   dataTableByNodeId?: Maybe<DataTable>;
-  /** Reads a single `DataTableManufacturingStep` using its globally unique `ID`. */
-  dataTableManufacturingStepByNodeId?: Maybe<DataTableManufacturingStep>;
   /** Reads a single `DataTableActiveIngredient` using its globally unique `ID`. */
   dataTableActiveIngredientByNodeId?: Maybe<DataTableActiveIngredient>;
   /** Reads a single `DataTableAdministrationRoute` using its globally unique `ID`. */
@@ -341,32 +362,48 @@ export type Query = Node & {
   dataTableAnnex2ByNodeId?: Maybe<DataTableAnnex2>;
   /** Reads a single `DataTableAtcCode` using its globally unique `ID`. */
   dataTableAtcCodeByNodeId?: Maybe<DataTableAtcCode>;
-  /** Reads a single `DataTableAtcTherapeuticCategory` using its globally unique `ID`. */
-  dataTableAtcTherapeuticCategoryByNodeId?: Maybe<DataTableAtcTherapeuticCategory>;
   /** Reads a single `DataTableContainer` using its globally unique `ID`. */
   dataTableContainerByNodeId?: Maybe<DataTableContainer>;
   /** Reads a single `DataTableCountry` using its globally unique `ID`. */
   dataTableCountryByNodeId?: Maybe<DataTableCountry>;
   /** Reads a single `DataTableDosageForm` using its globally unique `ID`. */
   dataTableDosageFormByNodeId?: Maybe<DataTableDosageForm>;
+  /** Reads a single `DataTableDosageFormGroup` using its globally unique `ID`. */
+  dataTableDosageFormGroupByNodeId?: Maybe<DataTableDosageFormGroup>;
   /** Reads a single `DataTableGenericIngredient` using its globally unique `ID`. */
   dataTableGenericIngredientByNodeId?: Maybe<DataTableGenericIngredient>;
-  /** Reads a single `DataTableIngredientsList` using its globally unique `ID`. */
-  dataTableIngredientsListByNodeId?: Maybe<DataTableIngredientsList>;
-  /** Reads a single `DataTableInternationalDiallingPrefix` using its globally unique `ID`. */
-  dataTableInternationalDiallingPrefixByNodeId?: Maybe<DataTableInternationalDiallingPrefix>;
   /** Reads a single `DataTableListOfSra` using its globally unique `ID`. */
   dataTableListOfSraByNodeId?: Maybe<DataTableListOfSra>;
-  /** Reads a single `DataTableManufacturingStepsSimpler` using its globally unique `ID`. */
-  dataTableManufacturingStepsSimplerByNodeId?: Maybe<DataTableManufacturingStepsSimpler>;
+  /** Reads a single `DataTableManufacturer` using its globally unique `ID`. */
+  dataTableManufacturerByNodeId?: Maybe<DataTableManufacturer>;
+  /** Reads a single `DataTableManufacturerApplicationJoin` using its globally unique `ID`. */
+  dataTableManufacturerApplicationJoinByNodeId?: Maybe<DataTableManufacturerApplicationJoin>;
+  /** Reads a single `DataTableManufacturerRepresentative` using its globally unique `ID`. */
+  dataTableManufacturerRepresentativeByNodeId?: Maybe<DataTableManufacturerRepresentative>;
+  /** Reads a single `DataTableManufacturerRepresentativeApplicationJoin` using its globally unique `ID`. */
+  dataTableManufacturerRepresentativeApplicationJoinByNodeId?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+  /** Reads a single `DataTablePermitChemical` using its globally unique `ID`. */
+  dataTablePermitChemicalByNodeId?: Maybe<DataTablePermitChemical>;
+  /** Reads a single `DataTablePermitChemicalApplicationJoin` using its globally unique `ID`. */
+  dataTablePermitChemicalApplicationJoinByNodeId?: Maybe<DataTablePermitChemicalApplicationJoin>;
+  /** Reads a single `DataTablePreRegisteredProductsProvisional` using its globally unique `ID`. */
+  dataTablePreRegisteredProductsProvisionalByNodeId?: Maybe<DataTablePreRegisteredProductsProvisional>;
+  /** Reads a single `DataTablePrequalManufacturer` using its globally unique `ID`. */
+  dataTablePrequalManufacturerByNodeId?: Maybe<DataTablePrequalManufacturer>;
+  /** Reads a single `DataTablePrequalManufacturerApplicationJoin` using its globally unique `ID`. */
+  dataTablePrequalManufacturerApplicationJoinByNodeId?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
   /** Reads a single `DataTableProcessingStep` using its globally unique `ID`. */
   dataTableProcessingStepByNodeId?: Maybe<DataTableProcessingStep>;
   /** Reads a single `DataTableProduct` using its globally unique `ID`. */
   dataTableProductByNodeId?: Maybe<DataTableProduct>;
   /** Reads a single `DataTableProductApplicationJoin` using its globally unique `ID`. */
   dataTableProductApplicationJoinByNodeId?: Maybe<DataTableProductApplicationJoin>;
-  /** Reads a single `DataTableProvince` using its globally unique `ID`. */
-  dataTableProvinceByNodeId?: Maybe<DataTableProvince>;
+  /** Reads a single `DataTableProvisionalProduct` using its globally unique `ID`. */
+  dataTableProvisionalProductByNodeId?: Maybe<DataTableProvisionalProduct>;
+  /** Reads a single `DataTableProvisionalProductApplicationJoin` using its globally unique `ID`. */
+  dataTableProvisionalProductApplicationJoinByNodeId?: Maybe<DataTableProvisionalProductApplicationJoin>;
+  /** Reads a single `DataTableScheduledChemical` using its globally unique `ID`. */
+  dataTableScheduledChemicalByNodeId?: Maybe<DataTableScheduledChemical>;
   /** Reads a single `DataTableStorageCondition` using its globally unique `ID`. */
   dataTableStorageConditionByNodeId?: Maybe<DataTableStorageCondition>;
   /** Reads a single `DataTableStorageConditionsSimplified` using its globally unique `ID`. */
@@ -383,6 +420,8 @@ export type Query = Node & {
   fileByNodeId?: Maybe<File>;
   /** Reads a single `Filter` using its globally unique `ID`. */
   filterByNodeId?: Maybe<Filter>;
+  /** Reads a single `GrafanaDashboardImage` using its globally unique `ID`. */
+  grafanaDashboardImageByNodeId?: Maybe<GrafanaDashboardImage>;
   /** Reads a single `Notification` using its globally unique `ID`. */
   notificationByNodeId?: Maybe<Notification>;
   /** Reads a single `Organisation` using its globally unique `ID`. */
@@ -395,8 +434,6 @@ export type Query = Node & {
   permissionNameByNodeId?: Maybe<PermissionName>;
   /** Reads a single `PermissionPolicy` using its globally unique `ID`. */
   permissionPolicyByNodeId?: Maybe<PermissionPolicy>;
-  /** Reads a single `ProductApplicationJoin` using its globally unique `ID`. */
-  productApplicationJoinByNodeId?: Maybe<ProductApplicationJoin>;
   /** Reads a single `Review` using its globally unique `ID`. */
   reviewByNodeId?: Maybe<Review>;
   /** Reads a single `ReviewAssignment` using its globally unique `ID`. */
@@ -439,8 +476,6 @@ export type Query = Node & {
   userApplicationJoinByNodeId?: Maybe<UserApplicationJoin>;
   /** Reads a single `UserOrganisation` using its globally unique `ID`. */
   userOrganisationByNodeId?: Maybe<UserOrganisation>;
-  /** Reads a single `UserOrganisationApplicationJoin` using its globally unique `ID`. */
-  userOrganisationApplicationJoinByNodeId?: Maybe<UserOrganisationApplicationJoin>;
   /** Reads a single `Verification` using its globally unique `ID`. */
   verificationByNodeId?: Maybe<Verification>;
 };
@@ -553,6 +588,19 @@ export type QueryApplicationResponsesArgs = {
   orderBy?: Maybe<Array<ApplicationResponsesOrderBy>>;
   condition?: Maybe<ApplicationResponseCondition>;
   filter?: Maybe<ApplicationResponseFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryApplicationReviewerActionsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
+  condition?: Maybe<ApplicationReviewerActionCondition>;
+  filter?: Maybe<ApplicationReviewerActionFilter>;
 };
 
 
@@ -674,19 +722,6 @@ export type QueryDataTablesArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableManufacturingStepsOrderBy>>;
-  condition?: Maybe<DataTableManufacturingStepCondition>;
-  filter?: Maybe<DataTableManufacturingStepFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryDataTableActiveIngredientsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -752,19 +787,6 @@ export type QueryDataTableAtcCodesArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableAtcTherapeuticCategoriesArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableAtcTherapeuticCategoriesOrderBy>>;
-  condition?: Maybe<DataTableAtcTherapeuticCategoryCondition>;
-  filter?: Maybe<DataTableAtcTherapeuticCategoryFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryDataTableContainersArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -804,6 +826,19 @@ export type QueryDataTableDosageFormsArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryDataTableDosageFormGroupsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableDosageFormGroupsOrderBy>>;
+  condition?: Maybe<DataTableDosageFormGroupCondition>;
+  filter?: Maybe<DataTableDosageFormGroupFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryDataTableGenericIngredientsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -813,32 +848,6 @@ export type QueryDataTableGenericIngredientsArgs = {
   orderBy?: Maybe<Array<DataTableGenericIngredientsOrderBy>>;
   condition?: Maybe<DataTableGenericIngredientCondition>;
   filter?: Maybe<DataTableGenericIngredientFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableIngredientsListsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableIngredientsListsOrderBy>>;
-  condition?: Maybe<DataTableIngredientsListCondition>;
-  filter?: Maybe<DataTableIngredientsListFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableInternationalDiallingPrefixesArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableInternationalDiallingPrefixesOrderBy>>;
-  condition?: Maybe<DataTableInternationalDiallingPrefixCondition>;
-  filter?: Maybe<DataTableInternationalDiallingPrefixFilter>;
 };
 
 
@@ -856,15 +865,119 @@ export type QueryDataTableListOfSrasArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepsSimplersArgs = {
+export type QueryDataTableManufacturersArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['Cursor']>;
   after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableManufacturingStepsSimplersOrderBy>>;
-  condition?: Maybe<DataTableManufacturingStepsSimplerCondition>;
-  filter?: Maybe<DataTableManufacturingStepsSimplerFilter>;
+  orderBy?: Maybe<Array<DataTableManufacturersOrderBy>>;
+  condition?: Maybe<DataTableManufacturerCondition>;
+  filter?: Maybe<DataTableManufacturerFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativesArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativesOrderBy>>;
+  condition?: Maybe<DataTableManufacturerRepresentativeCondition>;
+  filter?: Maybe<DataTableManufacturerRepresentativeFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativeApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerRepresentativeApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePermitChemicalsOrderBy>>;
+  condition?: Maybe<DataTablePermitChemicalCondition>;
+  filter?: Maybe<DataTablePermitChemicalFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePermitChemicalApplicationJoinCondition>;
+  filter?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePreRegisteredProductsProvisionalsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePreRegisteredProductsProvisionalsOrderBy>>;
+  condition?: Maybe<DataTablePreRegisteredProductsProvisionalCondition>;
+  filter?: Maybe<DataTablePreRegisteredProductsProvisionalFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturersArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePrequalManufacturersOrderBy>>;
+  condition?: Maybe<DataTablePrequalManufacturerCondition>;
+  filter?: Maybe<DataTablePrequalManufacturerFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePrequalManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
 };
 
 
@@ -908,15 +1021,41 @@ export type QueryDataTableProductApplicationJoinsArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableProvincesArgs = {
+export type QueryDataTableProvisionalProductsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['Cursor']>;
   after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableProvincesOrderBy>>;
-  condition?: Maybe<DataTableProvinceCondition>;
-  filter?: Maybe<DataTableProvinceFilter>;
+  orderBy?: Maybe<Array<DataTableProvisionalProductsOrderBy>>;
+  condition?: Maybe<DataTableProvisionalProductCondition>;
+  filter?: Maybe<DataTableProvisionalProductFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableProvisionalProductApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableProvisionalProductApplicationJoinCondition>;
+  filter?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableScheduledChemicalsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableScheduledChemicalsOrderBy>>;
+  condition?: Maybe<DataTableScheduledChemicalCondition>;
+  filter?: Maybe<DataTableScheduledChemicalFilter>;
 };
 
 
@@ -1021,6 +1160,19 @@ export type QueryFiltersArgs = {
   orderBy?: Maybe<Array<FiltersOrderBy>>;
   condition?: Maybe<FilterCondition>;
   filter?: Maybe<FilterFilter>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGrafanaDashboardImagesArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<GrafanaDashboardImagesOrderBy>>;
+  condition?: Maybe<GrafanaDashboardImageCondition>;
+  filter?: Maybe<GrafanaDashboardImageFilter>;
 };
 
 
@@ -1138,19 +1290,6 @@ export type QueryPostgresRowLevelsArgs = {
   orderBy?: Maybe<Array<PostgresRowLevelsOrderBy>>;
   condition?: Maybe<PostgresRowLevelCondition>;
   filter?: Maybe<PostgresRowLevelFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryProductApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<ProductApplicationJoinsOrderBy>>;
-  condition?: Maybe<ProductApplicationJoinCondition>;
-  filter?: Maybe<ProductApplicationJoinFilter>;
 };
 
 
@@ -1480,19 +1619,6 @@ export type QueryUserOrganisationsArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryUserOrganisationApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
-  condition?: Maybe<UserOrganisationApplicationJoinCondition>;
-  filter?: Maybe<UserOrganisationApplicationJoinFilter>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryVerificationsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -1560,6 +1686,19 @@ export type QueryApplicationResponseArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryApplicationReviewerActionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryApplicationReviewerActionByUserIdAndApplicationIdArgs = {
+  userId: Scalars['Int'];
+  applicationId: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryApplicationStageHistoryArgs = {
   id: Scalars['Int'];
 };
@@ -1602,12 +1741,6 @@ export type QueryDataTableByTableNameArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryDataTableActiveIngredientArgs = {
   id: Scalars['Int'];
 };
@@ -1638,12 +1771,6 @@ export type QueryDataTableAtcCodeArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableAtcTherapeuticCategoryArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryDataTableContainerArgs = {
   id: Scalars['Int'];
 };
@@ -1662,19 +1789,13 @@ export type QueryDataTableDosageFormArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryDataTableDosageFormGroupArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryDataTableGenericIngredientArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableIngredientsListArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableInternationalDiallingPrefixArgs = {
   id: Scalars['Int'];
 };
 
@@ -1686,7 +1807,55 @@ export type QueryDataTableListOfSraArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepsSimplerArgs = {
+export type QueryDataTableManufacturerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerApplicationJoinArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativeArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativeApplicationJoinArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalApplicationJoinArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePreRegisteredProductsProvisionalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturerApplicationJoinArgs = {
   id: Scalars['Int'];
 };
 
@@ -1710,7 +1879,19 @@ export type QueryDataTableProductApplicationJoinArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableProvinceArgs = {
+export type QueryDataTableProvisionalProductArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableProvisionalProductApplicationJoinArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableScheduledChemicalArgs = {
   id: Scalars['Int'];
 };
 
@@ -1789,6 +1970,13 @@ export type QueryFilterByCodeArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryGrafanaDashboardImageArgs = {
+  id: Scalars['Int'];
+  name: Scalars['String'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryNotificationArgs = {
   id: Scalars['Int'];
 };
@@ -1845,12 +2033,6 @@ export type QueryPermissionPolicyArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryPermissionPolicyByNameArgs = {
   name: Scalars['String'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryProductApplicationJoinArgs = {
-  id: Scalars['Int'];
 };
 
 
@@ -2016,19 +2198,6 @@ export type QueryUserApplicationJoinArgs = {
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUserOrganisationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryUserOrganisationByUserIdAndOrganisationIdArgs = {
-  userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryUserOrganisationApplicationJoinArgs = {
   id: Scalars['Int'];
 };
 
@@ -2294,6 +2463,12 @@ export type QueryApplicationResponseByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryApplicationReviewerActionByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryApplicationStageHistoryByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
@@ -2319,12 +2494,6 @@ export type QueryDataChangelogByNodeIdArgs = {
 
 /** The root query type which gives access points into the data universe. */
 export type QueryDataTableByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -2360,12 +2529,6 @@ export type QueryDataTableAtcCodeByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableAtcTherapeuticCategoryByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryDataTableContainerByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
@@ -2384,19 +2547,13 @@ export type QueryDataTableDosageFormByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryDataTableDosageFormGroupByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryDataTableGenericIngredientByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableIngredientsListByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryDataTableInternationalDiallingPrefixByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -2408,7 +2565,55 @@ export type QueryDataTableListOfSraByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableManufacturingStepsSimplerByNodeIdArgs = {
+export type QueryDataTableManufacturerByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerApplicationJoinByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativeByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableManufacturerRepresentativeApplicationJoinByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePermitChemicalApplicationJoinByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePreRegisteredProductsProvisionalByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturerByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTablePrequalManufacturerApplicationJoinByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -2432,7 +2637,19 @@ export type QueryDataTableProductApplicationJoinByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryDataTableProvinceByNodeIdArgs = {
+export type QueryDataTableProvisionalProductByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableProvisionalProductApplicationJoinByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryDataTableScheduledChemicalByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -2486,6 +2703,12 @@ export type QueryFilterByNodeIdArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryGrafanaDashboardImageByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryNotificationByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
@@ -2517,12 +2740,6 @@ export type QueryPermissionNameByNodeIdArgs = {
 
 /** The root query type which gives access points into the data universe. */
 export type QueryPermissionPolicyByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryProductApplicationJoinByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -2649,12 +2866,6 @@ export type QueryUserApplicationJoinByNodeIdArgs = {
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUserOrganisationByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryUserOrganisationApplicationJoinByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
@@ -3308,6 +3519,10 @@ export type ApplicationFilter = {
   trigger?: Maybe<TriggerFilter>;
   /** Filter by the object’s `outcomeRegistration` field. */
   outcomeRegistration?: Maybe<StringFilter>;
+  /** Filter by the object’s `reviewerList` field. */
+  reviewerList?: Maybe<StringListFilter>;
+  /** Filter by the object’s `assignerList` field. */
+  assignerList?: Maybe<StringListFilter>;
   /** Filter by the object’s `stage` field. */
   stage?: Maybe<StringFilter>;
   /** Filter by the object’s `stageNumber` field. */
@@ -3346,10 +3561,30 @@ export type ApplicationFilter = {
   dataChangelogs?: Maybe<ApplicationToManyDataChangelogFilter>;
   /** Some related `dataChangelogs` exist. */
   dataChangelogsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `dataTableManufacturerApplicationJoins` relation. */
+  dataTableManufacturerApplicationJoins?: Maybe<ApplicationToManyDataTableManufacturerApplicationJoinFilter>;
+  /** Some related `dataTableManufacturerApplicationJoins` exist. */
+  dataTableManufacturerApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `dataTableManufacturerRepresentativeApplicationJoins` relation. */
+  dataTableManufacturerRepresentativeApplicationJoins?: Maybe<ApplicationToManyDataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** Some related `dataTableManufacturerRepresentativeApplicationJoins` exist. */
+  dataTableManufacturerRepresentativeApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `dataTablePermitChemicalApplicationJoins` relation. */
+  dataTablePermitChemicalApplicationJoins?: Maybe<ApplicationToManyDataTablePermitChemicalApplicationJoinFilter>;
+  /** Some related `dataTablePermitChemicalApplicationJoins` exist. */
+  dataTablePermitChemicalApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `dataTablePrequalManufacturerApplicationJoins` relation. */
+  dataTablePrequalManufacturerApplicationJoins?: Maybe<ApplicationToManyDataTablePrequalManufacturerApplicationJoinFilter>;
+  /** Some related `dataTablePrequalManufacturerApplicationJoins` exist. */
+  dataTablePrequalManufacturerApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `dataTableProductApplicationJoins` relation. */
   dataTableProductApplicationJoins?: Maybe<ApplicationToManyDataTableProductApplicationJoinFilter>;
   /** Some related `dataTableProductApplicationJoins` exist. */
   dataTableProductApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `dataTableProvisionalProductApplicationJoins` relation. */
+  dataTableProvisionalProductApplicationJoins?: Maybe<ApplicationToManyDataTableProvisionalProductApplicationJoinFilter>;
+  /** Some related `dataTableProvisionalProductApplicationJoins` exist. */
+  dataTableProvisionalProductApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `filesByApplicationSerial` relation. */
   filesByApplicationSerial?: Maybe<ApplicationToManyFileFilter>;
   /** Some related `filesByApplicationSerial` exist. */
@@ -3362,10 +3597,6 @@ export type ApplicationFilter = {
   organisationApplicationJoins?: Maybe<ApplicationToManyOrganisationApplicationJoinFilter>;
   /** Some related `organisationApplicationJoins` exist. */
   organisationApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
-  /** Filter by the object’s `productApplicationJoins` relation. */
-  productApplicationJoins?: Maybe<ApplicationToManyProductApplicationJoinFilter>;
-  /** Some related `productApplicationJoins` exist. */
-  productApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `triggerQueues` relation. */
   triggerQueues?: Maybe<ApplicationToManyTriggerQueueFilter>;
   /** Some related `triggerQueues` exist. */
@@ -3378,14 +3609,14 @@ export type ApplicationFilter = {
   userApplicationJoins?: Maybe<ApplicationToManyUserApplicationJoinFilter>;
   /** Some related `userApplicationJoins` exist. */
   userApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
-  /** Filter by the object’s `userOrganisationApplicationJoins` relation. */
-  userOrganisationApplicationJoins?: Maybe<ApplicationToManyUserOrganisationApplicationJoinFilter>;
-  /** Some related `userOrganisationApplicationJoins` exist. */
-  userOrganisationApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `verifications` relation. */
   verifications?: Maybe<ApplicationToManyVerificationFilter>;
   /** Some related `verifications` exist. */
   verificationsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `applicationReviewerActions` relation. */
+  applicationReviewerActions?: Maybe<ApplicationToManyApplicationReviewerActionFilter>;
+  /** Some related `applicationReviewerActions` exist. */
+  applicationReviewerActionsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `template` relation. */
   template?: Maybe<TemplateFilter>;
   /** Filter by the object’s `user` relation. */
@@ -3895,16 +4126,6 @@ export type UserFilter = {
   address?: Maybe<StringFilter>;
   /** Filter by the object’s `country` field. */
   country?: Maybe<StringFilter>;
-  /** Filter by the object’s `province` field. */
-  province?: Maybe<StringFilter>;
-  /** Filter by the object’s `registrationDate` field. */
-  registrationDate?: Maybe<DatetimeFilter>;
-  /** Filter by the object’s `nationalId` field. */
-  nationalId?: Maybe<StringFilter>;
-  /** Filter by the object’s `foreignId` field. */
-  foreignId?: Maybe<JsonFilter>;
-  /** Filter by the object’s `foreignIdType` field. */
-  foreignIdType?: Maybe<StringFilter>;
   /** Filter by the object’s `fullName` field. */
   fullName?: Maybe<StringFilter>;
   /** Filter by the object’s `applications` relation. */
@@ -3963,6 +4184,10 @@ export type UserFilter = {
   userOrganisations?: Maybe<UserToManyUserOrganisationFilter>;
   /** Some related `userOrganisations` exist. */
   userOrganisationsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `applicationReviewerActions` relation. */
+  applicationReviewerActions?: Maybe<UserToManyApplicationReviewerActionFilter>;
+  /** Some related `applicationReviewerActions` exist. */
+  applicationReviewerActionsExist?: Maybe<Scalars['Boolean']>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<UserFilter>>;
   /** Checks for any expressions in this list. */
@@ -4693,32 +4918,38 @@ export type OrganisationFilter = {
   isSystemOrg?: Maybe<BooleanFilter>;
   /** Filter by the object’s `registrationDocumentation` field. */
   registrationDocumentation?: Maybe<JsonFilter>;
-  /** Filter by the object’s `agent` field. */
-  agent?: Maybe<JsonFilter>;
-  /** Filter by the object’s `contact` field. */
-  contact?: Maybe<JsonFilter>;
-  /** Filter by the object’s `authorisation` field. */
-  authorisation?: Maybe<JsonFilter>;
   /** Filter by the object’s `country` field. */
   country?: Maybe<StringFilter>;
   /** Filter by the object’s `province` field. */
   province?: Maybe<StringFilter>;
+  /** Filter by the object’s `contactEmail` field. */
+  contactEmail?: Maybe<StringFilter>;
+  /** Filter by the object’s `contactPhone` field. */
+  contactPhone?: Maybe<StringFilter>;
   /** Filter by the object’s `postalAddress` field. */
   postalAddress?: Maybe<StringFilter>;
-  /** Filter by the object’s `postalCountry` field. */
-  postalCountry?: Maybe<StringFilter>;
-  /** Filter by the object’s `postalProvince` field. */
-  postalProvince?: Maybe<StringFilter>;
-  /** Filter by the object’s `isActive` field. */
-  isActive?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `registrationDate` field. */
-  registrationDate?: Maybe<DatetimeFilter>;
-  /** Filter by the object’s `agentId` field. */
-  agentId?: Maybe<IntFilter>;
-  /** Filter by the object’s `type` field. */
-  type?: Maybe<StringFilter>;
-  /** Filter by the object’s `nifNumber` field. */
-  nifNumber?: Maybe<StringFilter>;
+  /** Filter by the object’s `localAgentName` field. */
+  localAgentName?: Maybe<StringFilter>;
+  /** Filter by the object’s `localAgentEmail` field. */
+  localAgentEmail?: Maybe<StringFilter>;
+  /** Filter by the object’s `localAgentPhoneNumber` field. */
+  localAgentPhoneNumber?: Maybe<StringFilter>;
+  /** Filter by the object’s `localAgentBusinessAddress` field. */
+  localAgentBusinessAddress?: Maybe<StringFilter>;
+  /** Filter by the object’s `license` field. */
+  license?: Maybe<JsonFilter>;
+  /** Filter by the object’s `businessCertificate` field. */
+  businessCertificate?: Maybe<JsonFilter>;
+  /** Filter by the object’s `tinLetter` field. */
+  tinLetter?: Maybe<JsonFilter>;
+  /** Filter by the object’s `subType` field. */
+  subType?: Maybe<StringFilter>;
+  /** Filter by the object’s `otherDocuments` field. */
+  otherDocuments?: Maybe<JsonFilter>;
+  /** Filter by the object’s `isSponsorCompany` field. */
+  isSponsorCompany?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `isChemicalImporter` field. */
+  isChemicalImporter?: Maybe<BooleanFilter>;
   /** Filter by the object’s `applicationsByOrgId` relation. */
   applicationsByOrgId?: Maybe<OrganisationToManyApplicationFilter>;
   /** Some related `applicationsByOrgId` exist. */
@@ -4979,10 +5210,6 @@ export type UserOrganisationFilter = {
   organisationId?: Maybe<IntFilter>;
   /** Filter by the object’s `userRole` field. */
   userRole?: Maybe<StringFilter>;
-  /** Filter by the object’s `userOrganisationApplicationJoins` relation. */
-  userOrganisationApplicationJoins?: Maybe<UserOrganisationToManyUserOrganisationApplicationJoinFilter>;
-  /** Some related `userOrganisationApplicationJoins` exist. */
-  userOrganisationApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Filter by the object’s `user` relation. */
   user?: Maybe<UserFilter>;
   /** Filter by the object’s `organisation` relation. */
@@ -4993,36 +5220,6 @@ export type UserOrganisationFilter = {
   or?: Maybe<Array<UserOrganisationFilter>>;
   /** Negates the expression. */
   not?: Maybe<UserOrganisationFilter>;
-};
-
-/** A filter to be used against many `UserOrganisationApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type UserOrganisationToManyUserOrganisationApplicationJoinFilter = {
-  /** Every related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: Maybe<UserOrganisationApplicationJoinFilter>;
-  /** Some related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: Maybe<UserOrganisationApplicationJoinFilter>;
-  /** No related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: Maybe<UserOrganisationApplicationJoinFilter>;
-};
-
-/** A filter to be used against `UserOrganisationApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type UserOrganisationApplicationJoinFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `applicationId` field. */
-  applicationId?: Maybe<IntFilter>;
-  /** Filter by the object’s `userOrganisationId` field. */
-  userOrganisationId?: Maybe<IntFilter>;
-  /** Filter by the object’s `application` relation. */
-  application?: Maybe<ApplicationFilter>;
-  /** Filter by the object’s `userOrganisation` relation. */
-  userOrganisation?: Maybe<UserOrganisationFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<UserOrganisationApplicationJoinFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<UserOrganisationApplicationJoinFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<UserOrganisationApplicationJoinFilter>;
 };
 
 /** A filter to be used against many `TemplatePermission` object types. All fields are combined with a logical ‘and.’ */
@@ -5475,6 +5672,8 @@ export type ReviewResponseFilter = {
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibilityFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<ReviewResponseStatusFilter>;
+  /** Filter by the object’s `isLatestReviewSubmission` field. */
+  isLatestReviewSubmission?: Maybe<BooleanFilter>;
   /** Filter by the object’s `stageNumber` field. */
   stageNumber?: Maybe<IntFilter>;
   /** Filter by the object’s `reviewResponsesByReviewResponseLinkId` relation. */
@@ -5862,6 +6061,108 @@ export type UserToManyUserOrganisationFilter = {
   none?: Maybe<UserOrganisationFilter>;
 };
 
+/** A filter to be used against many `ApplicationReviewerAction` object types. All fields are combined with a logical ‘and.’ */
+export type UserToManyApplicationReviewerActionFilter = {
+  /** Every related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<ApplicationReviewerActionFilter>;
+  /** Some related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<ApplicationReviewerActionFilter>;
+  /** No related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<ApplicationReviewerActionFilter>;
+};
+
+/** A filter to be used against `ApplicationReviewerAction` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationReviewerActionFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `userId` field. */
+  userId?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `reviewerAction` field. */
+  reviewerAction?: Maybe<ReviewerActionFilter>;
+  /** Filter by the object’s `assignerAction` field. */
+  assignerAction?: Maybe<AssignerActionFilter>;
+  /** Filter by the object’s `user` relation. */
+  user?: Maybe<UserFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<ApplicationReviewerActionFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<ApplicationReviewerActionFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<ApplicationReviewerActionFilter>;
+};
+
+/** A filter to be used against ReviewerAction fields. All fields are combined with a logical ‘and.’ */
+export type ReviewerActionFilter = {
+  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
+  isNull?: Maybe<Scalars['Boolean']>;
+  /** Equal to the specified value. */
+  equalTo?: Maybe<ReviewerAction>;
+  /** Not equal to the specified value. */
+  notEqualTo?: Maybe<ReviewerAction>;
+  /** Not equal to the specified value, treating null like an ordinary value. */
+  distinctFrom?: Maybe<ReviewerAction>;
+  /** Equal to the specified value, treating null like an ordinary value. */
+  notDistinctFrom?: Maybe<ReviewerAction>;
+  /** Included in the specified list. */
+  in?: Maybe<Array<ReviewerAction>>;
+  /** Not included in the specified list. */
+  notIn?: Maybe<Array<ReviewerAction>>;
+  /** Less than the specified value. */
+  lessThan?: Maybe<ReviewerAction>;
+  /** Less than or equal to the specified value. */
+  lessThanOrEqualTo?: Maybe<ReviewerAction>;
+  /** Greater than the specified value. */
+  greaterThan?: Maybe<ReviewerAction>;
+  /** Greater than or equal to the specified value. */
+  greaterThanOrEqualTo?: Maybe<ReviewerAction>;
+};
+
+export enum ReviewerAction {
+  SelfAssign = 'SELF_ASSIGN',
+  StartReview = 'START_REVIEW',
+  ViewReview = 'VIEW_REVIEW',
+  ContinueReview = 'CONTINUE_REVIEW',
+  MakeDecision = 'MAKE_DECISION',
+  RestartReview = 'RESTART_REVIEW',
+  UpdateReview = 'UPDATE_REVIEW',
+  AwaitingResponse = 'AWAITING_RESPONSE'
+}
+
+/** A filter to be used against AssignerAction fields. All fields are combined with a logical ‘and.’ */
+export type AssignerActionFilter = {
+  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
+  isNull?: Maybe<Scalars['Boolean']>;
+  /** Equal to the specified value. */
+  equalTo?: Maybe<AssignerAction>;
+  /** Not equal to the specified value. */
+  notEqualTo?: Maybe<AssignerAction>;
+  /** Not equal to the specified value, treating null like an ordinary value. */
+  distinctFrom?: Maybe<AssignerAction>;
+  /** Equal to the specified value, treating null like an ordinary value. */
+  notDistinctFrom?: Maybe<AssignerAction>;
+  /** Included in the specified list. */
+  in?: Maybe<Array<AssignerAction>>;
+  /** Not included in the specified list. */
+  notIn?: Maybe<Array<AssignerAction>>;
+  /** Less than the specified value. */
+  lessThan?: Maybe<AssignerAction>;
+  /** Less than or equal to the specified value. */
+  lessThanOrEqualTo?: Maybe<AssignerAction>;
+  /** Greater than the specified value. */
+  greaterThan?: Maybe<AssignerAction>;
+  /** Greater than or equal to the specified value. */
+  greaterThanOrEqualTo?: Maybe<AssignerAction>;
+};
+
+export enum AssignerAction {
+  Assign = 'ASSIGN',
+  ReAssign = 'RE_ASSIGN'
+}
+
 /** A filter to be used against many `ReviewResponse` object types. All fields are combined with a logical ‘and.’ */
 export type ReviewToManyReviewResponseFilter = {
   /** Every related `ReviewResponse` matches the filter criteria. All fields are combined with a logical ‘and.’ */
@@ -6019,6 +6320,306 @@ export type ApplicationToManyDataChangelogFilter = {
   none?: Maybe<DataChangelogFilter>;
 };
 
+/** A filter to be used against many `DataTableManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyDataTableManufacturerApplicationJoinFilter = {
+  /** Every related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+  /** Some related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+  /** No related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerApplicationJoinFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `dataTableManufacturerId` field. */
+  dataTableManufacturerId?: Maybe<IntFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Filter by the object’s `dataTableManufacturer` relation. */
+  dataTableManufacturer?: Maybe<DataTableManufacturerFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableManufacturerApplicationJoinFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableManufacturerApplicationJoinFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableManufacturer` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `manufacturer` field. */
+  manufacturer?: Maybe<StringFilter>;
+  /** Filter by the object’s `country` field. */
+  country?: Maybe<StringFilter>;
+  /** Filter by the object’s `address` field. */
+  address?: Maybe<StringFilter>;
+  /** Filter by the object’s `isAdditional` field. */
+  isAdditional?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `dataTableManufacturerApplicationJoins` relation. */
+  dataTableManufacturerApplicationJoins?: Maybe<DataTableManufacturerToManyDataTableManufacturerApplicationJoinFilter>;
+  /** Some related `dataTableManufacturerApplicationJoins` exist. */
+  dataTableManufacturerApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableManufacturerFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableManufacturerFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableManufacturerFilter>;
+};
+
+/** A filter to be used against many `DataTableManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerToManyDataTableManufacturerApplicationJoinFilter = {
+  /** Every related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+  /** Some related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+  /** No related `DataTableManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+/** A filter to be used against many `DataTableManufacturerRepresentativeApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyDataTableManufacturerRepresentativeApplicationJoinFilter = {
+  /** Every related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** Some related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** No related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableManufacturerRepresentativeApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerRepresentativeApplicationJoinFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `dataTableManufacturerRepresentativeId` field. */
+  dataTableManufacturerRepresentativeId?: Maybe<IntFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Filter by the object’s `dataTableManufacturerRepresentative` relation. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentativeFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableManufacturerRepresentative` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerRepresentativeFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `isActive` field. */
+  isActive?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `prequalificationDate` field. */
+  prequalificationDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `manufacturerDatabaseId` field. */
+  manufacturerDatabaseId?: Maybe<IntFilter>;
+  /** Filter by the object’s `manufacturerRegistrationId` field. */
+  manufacturerRegistrationId?: Maybe<StringFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `address` field. */
+  address?: Maybe<StringFilter>;
+  /** Filter by the object’s `country` field. */
+  country?: Maybe<StringFilter>;
+  /** Filter by the object’s `gmpScope` field. */
+  gmpScope?: Maybe<JsonFilter>;
+  /** Filter by the object’s `companyId` field. */
+  companyId?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicantId` field. */
+  applicantId?: Maybe<IntFilter>;
+  /** Filter by the object’s `companyName` field. */
+  companyName?: Maybe<StringFilter>;
+  /** Filter by the object’s `gmpCertificate` field. */
+  gmpCertificate?: Maybe<JsonFilter>;
+  /** Filter by the object’s `manufacturingLicence` field. */
+  manufacturingLicence?: Maybe<JsonFilter>;
+  /** Filter by the object’s `letterOfAuthorization` field. */
+  letterOfAuthorization?: Maybe<JsonFilter>;
+  /** Filter by the object’s `manufacturingCompanies` field. */
+  manufacturingCompanies?: Maybe<JsonFilter>;
+  /** Filter by the object’s `evaluationNotes` field. */
+  evaluationNotes?: Maybe<StringFilter>;
+  /** Filter by the object’s `gmpByWhoCertificate` field. */
+  gmpByWhoCertificate?: Maybe<JsonFilter>;
+  /** Filter by the object’s `dataTableManufacturerRepresentativeApplicationJoins` relation. */
+  dataTableManufacturerRepresentativeApplicationJoins?: Maybe<DataTableManufacturerRepresentativeToManyDataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** Some related `dataTableManufacturerRepresentativeApplicationJoins` exist. */
+  dataTableManufacturerRepresentativeApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableManufacturerRepresentativeFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableManufacturerRepresentativeFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableManufacturerRepresentativeFilter>;
+};
+
+/** A filter to be used against many `DataTableManufacturerRepresentativeApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableManufacturerRepresentativeToManyDataTableManufacturerRepresentativeApplicationJoinFilter = {
+  /** Every related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** Some related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+  /** No related `DataTableManufacturerRepresentativeApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+/** A filter to be used against many `DataTablePermitChemicalApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyDataTablePermitChemicalApplicationJoinFilter = {
+  /** Every related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+  /** Some related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+  /** No related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTablePermitChemicalApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePermitChemicalApplicationJoinFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `dataTablePermitChemicalId` field. */
+  dataTablePermitChemicalId?: Maybe<IntFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Filter by the object’s `dataTablePermitChemical` relation. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemicalFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTablePermitChemicalApplicationJoinFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTablePermitChemicalApplicationJoinFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTablePermitChemical` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePermitChemicalFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `permitNo` field. */
+  permitNo?: Maybe<StringFilter>;
+  /** Filter by the object’s `registrationDate` field. */
+  registrationDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `chemicals` field. */
+  chemicals?: Maybe<JsonFilter>;
+  /** Filter by the object’s `companyId` field. */
+  companyId?: Maybe<IntFilter>;
+  /** Filter by the object’s `companyName` field. */
+  companyName?: Maybe<StringFilter>;
+  /** Filter by the object’s `chemicalsFilterData` field. */
+  chemicalsFilterData?: Maybe<StringFilter>;
+  /** Filter by the object’s `dataTablePermitChemicalApplicationJoins` relation. */
+  dataTablePermitChemicalApplicationJoins?: Maybe<DataTablePermitChemicalToManyDataTablePermitChemicalApplicationJoinFilter>;
+  /** Some related `dataTablePermitChemicalApplicationJoins` exist. */
+  dataTablePermitChemicalApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTablePermitChemicalFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTablePermitChemicalFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTablePermitChemicalFilter>;
+};
+
+/** A filter to be used against many `DataTablePermitChemicalApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePermitChemicalToManyDataTablePermitChemicalApplicationJoinFilter = {
+  /** Every related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+  /** Some related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+  /** No related `DataTablePermitChemicalApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+/** A filter to be used against many `DataTablePrequalManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyDataTablePrequalManufacturerApplicationJoinFilter = {
+  /** Every related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+  /** Some related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+  /** No related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTablePrequalManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePrequalManufacturerApplicationJoinFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `dataTablePrequalManufacturerId` field. */
+  dataTablePrequalManufacturerId?: Maybe<IntFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Filter by the object’s `dataTablePrequalManufacturer` relation. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturerFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTablePrequalManufacturer` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePrequalManufacturerFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `lookupId` field. */
+  lookupId?: Maybe<IntFilter>;
+  /** Filter by the object’s `isActive` field. */
+  isActive?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `manufacturerId` field. */
+  manufacturerId?: Maybe<StringFilter>;
+  /** Filter by the object’s `prequalificationDate` field. */
+  prequalificationDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `address` field. */
+  address?: Maybe<StringFilter>;
+  /** Filter by the object’s `country` field. */
+  country?: Maybe<StringFilter>;
+  /** Filter by the object’s `gmpScope` field. */
+  gmpScope?: Maybe<JsonFilter>;
+  /** Filter by the object’s `permitNo` field. */
+  permitNo?: Maybe<StringFilter>;
+  /** Filter by the object’s `dateIssued` field. */
+  dateIssued?: Maybe<StringFilter>;
+  /** Filter by the object’s `manufacturingLicence` field. */
+  manufacturingLicence?: Maybe<JsonFilter>;
+  /** Filter by the object’s `dataTablePrequalManufacturerApplicationJoins` relation. */
+  dataTablePrequalManufacturerApplicationJoins?: Maybe<DataTablePrequalManufacturerToManyDataTablePrequalManufacturerApplicationJoinFilter>;
+  /** Some related `dataTablePrequalManufacturerApplicationJoins` exist. */
+  dataTablePrequalManufacturerApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTablePrequalManufacturerFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTablePrequalManufacturerFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTablePrequalManufacturerFilter>;
+};
+
+/** A filter to be used against many `DataTablePrequalManufacturerApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePrequalManufacturerToManyDataTablePrequalManufacturerApplicationJoinFilter = {
+  /** Every related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+  /** Some related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+  /** No related `DataTablePrequalManufacturerApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+};
+
 /** A filter to be used against many `DataTableProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
 export type ApplicationToManyDataTableProductApplicationJoinFilter = {
   /** Every related `DataTableProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
@@ -6039,8 +6640,6 @@ export type DataTableProductApplicationJoinFilter = {
   dataTableProductId?: Maybe<IntFilter>;
   /** Filter by the object’s `application` relation. */
   application?: Maybe<ApplicationFilter>;
-  /** Filter by the object’s `dataTableProduct` relation. */
-  dataTableProduct?: Maybe<DataTableProductFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableProductApplicationJoinFilter>>;
   /** Checks for any expressions in this list. */
@@ -6049,92 +6648,126 @@ export type DataTableProductApplicationJoinFilter = {
   not?: Maybe<DataTableProductApplicationJoinFilter>;
 };
 
-/** A filter to be used against `DataTableProduct` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableProductFilter = {
+/** A filter to be used against many `DataTableProvisionalProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyDataTableProvisionalProductApplicationJoinFilter = {
+  /** Every related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+  /** Some related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+  /** No related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableProvisionalProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableProvisionalProductApplicationJoinFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `origin` field. */
-  origin?: Maybe<StringFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `dataTableProvisionalProductId` field. */
+  dataTableProvisionalProductId?: Maybe<IntFilter>;
+  /** Filter by the object’s `application` relation. */
+  application?: Maybe<ApplicationFilter>;
+  /** Filter by the object’s `dataTableProvisionalProduct` relation. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProductFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableProvisionalProductApplicationJoinFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableProvisionalProductApplicationJoinFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+};
+
+/** A filter to be used against `DataTableProvisionalProduct` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableProvisionalProductFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `fullName` field. */
+  fullName?: Maybe<StringFilter>;
   /** Filter by the object’s `isActive` field. */
   isActive?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `expiryDate` field. */
-  expiryDate?: Maybe<DatetimeFilter>;
-  /** Filter by the object’s `registration` field. */
-  registration?: Maybe<StringFilter>;
-  /** Filter by the object’s `applicantName` field. */
-  applicantName?: Maybe<StringFilter>;
-  /** Filter by the object’s `registrationDate` field. */
-  registrationDate?: Maybe<DatetimeFilter>;
-  /** Filter by the object’s `responsiblePerson` field. */
-  responsiblePerson?: Maybe<JsonFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
-  /** Filter by the object’s `atcCode` field. */
-  atcCode?: Maybe<StringFilter>;
-  /** Filter by the object’s `atcClass` field. */
-  atcClass?: Maybe<StringFilter>;
-  /** Filter by the object’s `companyId` field. */
-  companyId?: Maybe<IntFilter>;
-  /** Filter by the object’s `dimensions` field. */
-  dimensions?: Maybe<JsonFilter>;
+  /** Filter by the object’s `productId` field. */
+  productId?: Maybe<StringFilter>;
   /** Filter by the object’s `dosageForm` field. */
   dosageForm?: Maybe<StringFilter>;
+  /** Filter by the object’s `originalId` field. */
+  originalId?: Maybe<StringFilter>;
+  /** Filter by the object’s `expiryDate` field. */
+  expiryDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `sponsorName` field. */
+  sponsorName?: Maybe<StringFilter>;
+  /** Filter by the object’s `registeredIn` field. */
+  registeredIn?: Maybe<StringFilter>;
+  /** Filter by the object’s `registrationDate` field. */
+  registrationDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `registrationSerial` field. */
+  registrationSerial?: Maybe<StringFilter>;
+  /** Filter by the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<StringFilter>;
+  /** Filter by the object’s `tradeName` field. */
+  tradeName?: Maybe<StringFilter>;
+  /** Filter by the object’s `companyId` field. */
+  companyId?: Maybe<IntFilter>;
+  /** Filter by the object’s `shelfLife` field. */
+  shelfLife?: Maybe<StringFilter>;
   /** Filter by the object’s `applicantId` field. */
   applicantId?: Maybe<IntFilter>;
   /** Filter by the object’s `companyName` field. */
   companyName?: Maybe<StringFilter>;
-  /** Filter by the object’s `formulations` field. */
-  formulations?: Maybe<JsonFilter>;
-  /** Filter by the object’s `prescription` field. */
-  prescription?: Maybe<StringFilter>;
-  /** Filter by the object’s `genericNames` field. */
-  genericNames?: Maybe<JsonFilter>;
-  /** Filter by the object’s `medicineType` field. */
-  medicineType?: Maybe<StringFilter>;
-  /** Filter by the object’s `applicationType` field. */
-  applicationType?: Maybe<StringFilter>;
-  /** Filter by the object’s `primaryContainer` field. */
-  primaryContainer?: Maybe<StringFilter>;
-  /** Filter by the object’s `shelfLifeOpened` field. */
-  shelfLifeOpened?: Maybe<StringFilter>;
-  /** Filter by the object’s `manufacturersList` field. */
-  manufacturersList?: Maybe<JsonFilter>;
-  /** Filter by the object’s `shelfLifeProposed` field. */
-  shelfLifeProposed?: Maybe<StringFilter>;
-  /** Filter by the object’s `administrationRoute` field. */
-  administrationRoute?: Maybe<StringFilter>;
-  /** Filter by the object’s `isLocallyManufactured` field. */
-  isLocallyManufactured?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `shelfLifeReconstructed` field. */
-  shelfLifeReconstructed?: Maybe<StringFilter>;
-  /** Filter by the object’s `storageConditionsOpened` field. */
-  storageConditionsOpened?: Maybe<StringFilter>;
-  /** Filter by the object’s `storageConditionsProposed` field. */
-  storageConditionsProposed?: Maybe<StringFilter>;
-  /** Filter by the object’s `genericNamesFilterData` field. */
-  genericNamesFilterData?: Maybe<StringFilter>;
-  /** Filter by the object’s `manufacturersListFilterData` field. */
-  manufacturersListFilterData?: Maybe<StringFilter>;
-  /** Filter by the object’s `dataTableProductApplicationJoins` relation. */
-  dataTableProductApplicationJoins?: Maybe<DataTableProductToManyDataTableProductApplicationJoinFilter>;
-  /** Some related `dataTableProductApplicationJoins` exist. */
-  dataTableProductApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
+  /** Filter by the object’s `packagingSizes` field. */
+  packagingSizes?: Maybe<JsonFilter>;
+  /** Filter by the object’s `storageConditions` field. */
+  storageConditions?: Maybe<StringFilter>;
+  /** Filter by the object’s `activeIngredients` field. */
+  activeIngredients?: Maybe<JsonFilter>;
+  /** Filter by the object’s `medicalProductClassification` field. */
+  medicalProductClassification?: Maybe<StringFilter>;
+  /** Filter by the object’s `manufacturers` field. */
+  manufacturers?: Maybe<JsonFilter>;
+  /** Filter by the object’s `atcCode` field. */
+  atcCode?: Maybe<JsonFilter>;
+  /** Filter by the object’s `pharmacopeia` field. */
+  pharmacopeia?: Maybe<StringFilter>;
+  /** Filter by the object’s `gmpCertificate` field. */
+  gmpCertificate?: Maybe<JsonFilter>;
+  /** Filter by the object’s `prodRegCertificate` field. */
+  prodRegCertificate?: Maybe<JsonFilter>;
+  /** Filter by the object’s `prequalified` field. */
+  prequalified?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `manufacturerPrequalified` field. */
+  manufacturerPrequalified?: Maybe<JsonFilter>;
+  /** Filter by the object’s `loaSource` field. */
+  loaSource?: Maybe<StringFilter>;
+  /** Filter by the object’s `letterOfAuthorisation` field. */
+  letterOfAuthorisation?: Maybe<JsonFilter>;
+  /** Filter by the object’s `packagingSizesForm` field. */
+  packagingSizesForm?: Maybe<JsonFilter>;
+  /** Filter by the object’s `packagingSizesFilterData` field. */
+  packagingSizesFilterData?: Maybe<StringFilter>;
+  /** Filter by the object’s `manufacturersFilterData` field. */
+  manufacturersFilterData?: Maybe<StringFilter>;
+  /** Filter by the object’s `activeIngredientsFilterData` field. */
+  activeIngredientsFilterData?: Maybe<StringFilter>;
+  /** Filter by the object’s `dataTableProvisionalProductApplicationJoins` relation. */
+  dataTableProvisionalProductApplicationJoins?: Maybe<DataTableProvisionalProductToManyDataTableProvisionalProductApplicationJoinFilter>;
+  /** Some related `dataTableProvisionalProductApplicationJoins` exist. */
+  dataTableProvisionalProductApplicationJoinsExist?: Maybe<Scalars['Boolean']>;
   /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableProductFilter>>;
+  and?: Maybe<Array<DataTableProvisionalProductFilter>>;
   /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableProductFilter>>;
+  or?: Maybe<Array<DataTableProvisionalProductFilter>>;
   /** Negates the expression. */
-  not?: Maybe<DataTableProductFilter>;
+  not?: Maybe<DataTableProvisionalProductFilter>;
 };
 
-/** A filter to be used against many `DataTableProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableProductToManyDataTableProductApplicationJoinFilter = {
-  /** Every related `DataTableProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: Maybe<DataTableProductApplicationJoinFilter>;
-  /** Some related `DataTableProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: Maybe<DataTableProductApplicationJoinFilter>;
-  /** No related `DataTableProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: Maybe<DataTableProductApplicationJoinFilter>;
+/** A filter to be used against many `DataTableProvisionalProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableProvisionalProductToManyDataTableProvisionalProductApplicationJoinFilter = {
+  /** Every related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+  /** Some related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+  /** No related `DataTableProvisionalProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
 };
 
 /** A filter to be used against many `File` object types. All fields are combined with a logical ‘and.’ */
@@ -6167,34 +6800,6 @@ export type ApplicationToManyOrganisationApplicationJoinFilter = {
   none?: Maybe<OrganisationApplicationJoinFilter>;
 };
 
-/** A filter to be used against many `ProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type ApplicationToManyProductApplicationJoinFilter = {
-  /** Every related `ProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: Maybe<ProductApplicationJoinFilter>;
-  /** Some related `ProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: Maybe<ProductApplicationJoinFilter>;
-  /** No related `ProductApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: Maybe<ProductApplicationJoinFilter>;
-};
-
-/** A filter to be used against `ProductApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type ProductApplicationJoinFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `applicationId` field. */
-  applicationId?: Maybe<IntFilter>;
-  /** Filter by the object’s `productId` field. */
-  productId?: Maybe<IntFilter>;
-  /** Filter by the object’s `application` relation. */
-  application?: Maybe<ApplicationFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<ProductApplicationJoinFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<ProductApplicationJoinFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<ProductApplicationJoinFilter>;
-};
-
 /** A filter to be used against many `TriggerQueue` object types. All fields are combined with a logical ‘and.’ */
 export type ApplicationToManyTriggerQueueFilter = {
   /** Every related `TriggerQueue` matches the filter criteria. All fields are combined with a logical ‘and.’ */
@@ -6223,16 +6828,6 @@ export type ApplicationToManyUserApplicationJoinFilter = {
   some?: Maybe<UserApplicationJoinFilter>;
   /** No related `UserApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
   none?: Maybe<UserApplicationJoinFilter>;
-};
-
-/** A filter to be used against many `UserOrganisationApplicationJoin` object types. All fields are combined with a logical ‘and.’ */
-export type ApplicationToManyUserOrganisationApplicationJoinFilter = {
-  /** Every related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: Maybe<UserOrganisationApplicationJoinFilter>;
-  /** Some related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: Maybe<UserOrganisationApplicationJoinFilter>;
-  /** No related `UserOrganisationApplicationJoin` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: Maybe<UserOrganisationApplicationJoinFilter>;
 };
 
 /** A filter to be used against many `Verification` object types. All fields are combined with a logical ‘and.’ */
@@ -6275,6 +6870,16 @@ export type VerificationFilter = {
   or?: Maybe<Array<VerificationFilter>>;
   /** Negates the expression. */
   not?: Maybe<VerificationFilter>;
+};
+
+/** A filter to be used against many `ApplicationReviewerAction` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationToManyApplicationReviewerActionFilter = {
+  /** Every related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: Maybe<ApplicationReviewerActionFilter>;
+  /** Some related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: Maybe<ApplicationReviewerActionFilter>;
+  /** No related `ApplicationReviewerAction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: Maybe<ApplicationReviewerActionFilter>;
 };
 
 /** A connection to a list of `ActionQueue` values. */
@@ -6365,6 +6970,8 @@ export type Application = Node & {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Reads a single `Template` that is related to this `Application`. */
   template?: Maybe<Template>;
   /** Reads a single `User` that is related to this `Application`. */
@@ -6387,26 +6994,34 @@ export type Application = Node & {
   applicationStageHistories: ApplicationStageHistoriesConnection;
   /** Reads and enables pagination through a set of `DataChangelog`. */
   dataChangelogs: DataChangelogsConnection;
+  /** Reads and enables pagination through a set of `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturerApplicationJoins: DataTableManufacturerApplicationJoinsConnection;
+  /** Reads and enables pagination through a set of `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentativeApplicationJoins: DataTableManufacturerRepresentativeApplicationJoinsConnection;
+  /** Reads and enables pagination through a set of `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemicalApplicationJoins: DataTablePermitChemicalApplicationJoinsConnection;
+  /** Reads and enables pagination through a set of `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturerApplicationJoins: DataTablePrequalManufacturerApplicationJoinsConnection;
   /** Reads and enables pagination through a set of `DataTableProductApplicationJoin`. */
   dataTableProductApplicationJoins: DataTableProductApplicationJoinsConnection;
+  /** Reads and enables pagination through a set of `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProductApplicationJoins: DataTableProvisionalProductApplicationJoinsConnection;
   /** Reads and enables pagination through a set of `File`. */
   filesByApplicationSerial: FilesConnection;
   /** Reads and enables pagination through a set of `Notification`. */
   notifications: NotificationsConnection;
   /** Reads and enables pagination through a set of `OrganisationApplicationJoin`. */
   organisationApplicationJoins: OrganisationApplicationJoinsConnection;
-  /** Reads and enables pagination through a set of `ProductApplicationJoin`. */
-  productApplicationJoins: ProductApplicationJoinsConnection;
   /** Reads and enables pagination through a set of `TriggerQueue`. */
   triggerQueues: TriggerQueuesConnection;
   /** Reads and enables pagination through a set of `TriggerSchedule`. */
   triggerSchedules: TriggerSchedulesConnection;
   /** Reads and enables pagination through a set of `UserApplicationJoin`. */
   userApplicationJoins: UserApplicationJoinsConnection;
-  /** Reads and enables pagination through a set of `UserOrganisationApplicationJoin`. */
-  userOrganisationApplicationJoins: UserOrganisationApplicationJoinsConnection;
   /** Reads and enables pagination through a set of `Verification`. */
   verifications: VerificationsConnection;
+  /** Reads and enables pagination through a set of `ApplicationReviewerAction`. */
+  applicationReviewerActions: ApplicationReviewerActionsConnection;
   stage?: Maybe<Scalars['String']>;
   stageNumber?: Maybe<Scalars['Int']>;
   status?: Maybe<ApplicationStatus>;
@@ -6509,6 +7124,54 @@ export type ApplicationDataChangelogsArgs = {
 };
 
 
+export type ApplicationDataTableManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+
+export type ApplicationDataTableManufacturerRepresentativeApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerRepresentativeApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+
+export type ApplicationDataTablePermitChemicalApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePermitChemicalApplicationJoinCondition>;
+  filter?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+
+export type ApplicationDataTablePrequalManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePrequalManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+};
+
+
 export type ApplicationDataTableProductApplicationJoinsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -6518,6 +7181,18 @@ export type ApplicationDataTableProductApplicationJoinsArgs = {
   orderBy?: Maybe<Array<DataTableProductApplicationJoinsOrderBy>>;
   condition?: Maybe<DataTableProductApplicationJoinCondition>;
   filter?: Maybe<DataTableProductApplicationJoinFilter>;
+};
+
+
+export type ApplicationDataTableProvisionalProductApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableProvisionalProductApplicationJoinCondition>;
+  filter?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
 };
 
 
@@ -6557,18 +7232,6 @@ export type ApplicationOrganisationApplicationJoinsArgs = {
 };
 
 
-export type ApplicationProductApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<ProductApplicationJoinsOrderBy>>;
-  condition?: Maybe<ProductApplicationJoinCondition>;
-  filter?: Maybe<ProductApplicationJoinFilter>;
-};
-
-
 export type ApplicationTriggerQueuesArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -6605,18 +7268,6 @@ export type ApplicationUserApplicationJoinsArgs = {
 };
 
 
-export type ApplicationUserOrganisationApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
-  condition?: Maybe<UserOrganisationApplicationJoinCondition>;
-  filter?: Maybe<UserOrganisationApplicationJoinFilter>;
-};
-
-
 export type ApplicationVerificationsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
@@ -6626,6 +7277,18 @@ export type ApplicationVerificationsArgs = {
   orderBy?: Maybe<Array<VerificationsOrderBy>>;
   condition?: Maybe<VerificationCondition>;
   filter?: Maybe<VerificationFilter>;
+};
+
+
+export type ApplicationApplicationReviewerActionsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
+  condition?: Maybe<ApplicationReviewerActionCondition>;
+  filter?: Maybe<ApplicationReviewerActionFilter>;
 };
 
 export type Template = Node & {
@@ -6958,6 +7621,10 @@ export enum ApplicationsOrderBy {
   TriggerDesc = 'TRIGGER_DESC',
   OutcomeRegistrationAsc = 'OUTCOME_REGISTRATION_ASC',
   OutcomeRegistrationDesc = 'OUTCOME_REGISTRATION_DESC',
+  ReviewerListAsc = 'REVIEWER_LIST_ASC',
+  ReviewerListDesc = 'REVIEWER_LIST_DESC',
+  AssignerListAsc = 'ASSIGNER_LIST_ASC',
+  AssignerListDesc = 'ASSIGNER_LIST_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -6988,6 +7655,10 @@ export type ApplicationCondition = {
   trigger?: Maybe<Trigger>;
   /** Checks for equality with the object’s `outcomeRegistration` field. */
   outcomeRegistration?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `reviewerList` field. */
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Checks for equality with the object’s `assignerList` field. */
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 /** A connection to a list of `Application` values. */
@@ -7204,11 +7875,6 @@ export type User = Node & {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   /** Reads and enables pagination through a set of `Application`. */
   applications: ApplicationsConnection;
@@ -7238,6 +7904,8 @@ export type User = Node & {
   userApplicationJoins: UserApplicationJoinsConnection;
   /** Reads and enables pagination through a set of `UserOrganisation`. */
   userOrganisations: UserOrganisationsConnection;
+  /** Reads and enables pagination through a set of `ApplicationReviewerAction`. */
+  applicationReviewerActions: ApplicationReviewerActionsConnection;
 };
 
 
@@ -7406,6 +8074,18 @@ export type UserUserOrganisationsArgs = {
   orderBy?: Maybe<Array<UserOrganisationsOrderBy>>;
   condition?: Maybe<UserOrganisationCondition>;
   filter?: Maybe<UserOrganisationFilter>;
+};
+
+
+export type UserApplicationReviewerActionsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
+  condition?: Maybe<ApplicationReviewerActionCondition>;
+  filter?: Maybe<ApplicationReviewerActionFilter>;
 };
 
 /** Methods to use when ordering `Review`. */
@@ -7829,6 +8509,8 @@ export enum ReviewResponsesOrderBy {
   RecommendedApplicantVisibilityDesc = 'RECOMMENDED_APPLICANT_VISIBILITY_DESC',
   StatusAsc = 'STATUS_ASC',
   StatusDesc = 'STATUS_DESC',
+  IsLatestReviewSubmissionAsc = 'IS_LATEST_REVIEW_SUBMISSION_ASC',
+  IsLatestReviewSubmissionDesc = 'IS_LATEST_REVIEW_SUBMISSION_DESC',
   StageNumberAsc = 'STAGE_NUMBER_ASC',
   StageNumberDesc = 'STAGE_NUMBER_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -7867,6 +8549,8 @@ export type ReviewResponseCondition = {
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<ReviewResponseStatus>;
+  /** Checks for equality with the object’s `isLatestReviewSubmission` field. */
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `stageNumber` field. */
   stageNumber?: Maybe<Scalars['Int']>;
 };
@@ -7903,6 +8587,7 @@ export type ReviewResponse = Node & {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   /** Reads a single `ApplicationResponse` that is related to this `ReviewResponse`. */
   applicationResponse?: Maybe<ApplicationResponse>;
@@ -8440,19 +9125,22 @@ export type Organisation = Node & {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   /** Reads and enables pagination through a set of `Application`. */
   applicationsByOrgId: ApplicationsConnection;
   /** Reads and enables pagination through a set of `ReviewAssignment`. */
@@ -9185,78 +9873,6 @@ export type UserOrganisation = Node & {
   user?: Maybe<User>;
   /** Reads a single `Organisation` that is related to this `UserOrganisation`. */
   organisation?: Maybe<Organisation>;
-  /** Reads and enables pagination through a set of `UserOrganisationApplicationJoin`. */
-  userOrganisationApplicationJoins: UserOrganisationApplicationJoinsConnection;
-};
-
-
-export type UserOrganisationUserOrganisationApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
-  condition?: Maybe<UserOrganisationApplicationJoinCondition>;
-  filter?: Maybe<UserOrganisationApplicationJoinFilter>;
-};
-
-/** Methods to use when ordering `UserOrganisationApplicationJoin`. */
-export enum UserOrganisationApplicationJoinsOrderBy {
-  Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  ApplicationIdAsc = 'APPLICATION_ID_ASC',
-  ApplicationIdDesc = 'APPLICATION_ID_DESC',
-  UserOrganisationIdAsc = 'USER_ORGANISATION_ID_ASC',
-  UserOrganisationIdDesc = 'USER_ORGANISATION_ID_DESC',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
-/** A condition to be used against `UserOrganisationApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type UserOrganisationApplicationJoinCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `applicationId` field. */
-  applicationId?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `userOrganisationId` field. */
-  userOrganisationId?: Maybe<Scalars['Int']>;
-};
-
-/** A connection to a list of `UserOrganisationApplicationJoin` values. */
-export type UserOrganisationApplicationJoinsConnection = {
-  __typename?: 'UserOrganisationApplicationJoinsConnection';
-  /** A list of `UserOrganisationApplicationJoin` objects. */
-  nodes: Array<Maybe<UserOrganisationApplicationJoin>>;
-  /** A list of edges which contains the `UserOrganisationApplicationJoin` and cursor to aid in pagination. */
-  edges: Array<UserOrganisationApplicationJoinsEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `UserOrganisationApplicationJoin` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-export type UserOrganisationApplicationJoin = Node & {
-  __typename?: 'UserOrganisationApplicationJoin';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  applicationId: Scalars['Int'];
-  userOrganisationId: Scalars['Int'];
-  /** Reads a single `Application` that is related to this `UserOrganisationApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** Reads a single `UserOrganisation` that is related to this `UserOrganisationApplicationJoin`. */
-  userOrganisation?: Maybe<UserOrganisation>;
-};
-
-/** A `UserOrganisationApplicationJoin` edge in the connection. */
-export type UserOrganisationApplicationJoinsEdge = {
-  __typename?: 'UserOrganisationApplicationJoinsEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `UserOrganisationApplicationJoin` at the end of the edge. */
-  node?: Maybe<UserOrganisationApplicationJoin>;
 };
 
 /** A `UserOrganisation` edge in the connection. */
@@ -9441,6 +10057,74 @@ export type UserApplicationJoinsEdge = {
   cursor?: Maybe<Scalars['Cursor']>;
   /** The `UserApplicationJoin` at the end of the edge. */
   node?: Maybe<UserApplicationJoin>;
+};
+
+/** Methods to use when ordering `ApplicationReviewerAction`. */
+export enum ApplicationReviewerActionsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  UserIdAsc = 'USER_ID_ASC',
+  UserIdDesc = 'USER_ID_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  ReviewerActionAsc = 'REVIEWER_ACTION_ASC',
+  ReviewerActionDesc = 'REVIEWER_ACTION_DESC',
+  AssignerActionAsc = 'ASSIGNER_ACTION_ASC',
+  AssignerActionDesc = 'ASSIGNER_ACTION_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `ApplicationReviewerAction` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type ApplicationReviewerActionCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `userId` field. */
+  userId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `reviewerAction` field. */
+  reviewerAction?: Maybe<ReviewerAction>;
+  /** Checks for equality with the object’s `assignerAction` field. */
+  assignerAction?: Maybe<AssignerAction>;
+};
+
+/** A connection to a list of `ApplicationReviewerAction` values. */
+export type ApplicationReviewerActionsConnection = {
+  __typename?: 'ApplicationReviewerActionsConnection';
+  /** A list of `ApplicationReviewerAction` objects. */
+  nodes: Array<Maybe<ApplicationReviewerAction>>;
+  /** A list of edges which contains the `ApplicationReviewerAction` and cursor to aid in pagination. */
+  edges: Array<ApplicationReviewerActionsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `ApplicationReviewerAction` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type ApplicationReviewerAction = Node & {
+  __typename?: 'ApplicationReviewerAction';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  userId: Scalars['Int'];
+  applicationId: Scalars['Int'];
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  /** Reads a single `User` that is related to this `ApplicationReviewerAction`. */
+  user?: Maybe<User>;
+  /** Reads a single `Application` that is related to this `ApplicationReviewerAction`. */
+  application?: Maybe<Application>;
+};
+
+/** A `ApplicationReviewerAction` edge in the connection. */
+export type ApplicationReviewerActionsEdge = {
+  __typename?: 'ApplicationReviewerActionsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `ApplicationReviewerAction` at the end of the edge. */
+  node?: Maybe<ApplicationReviewerAction>;
 };
 
 export type TemplateStage = Node & {
@@ -10112,6 +10796,360 @@ export type ActivityLogsEdge = {
   node?: Maybe<ActivityLog>;
 };
 
+/** Methods to use when ordering `DataTableManufacturerApplicationJoin`. */
+export enum DataTableManufacturerApplicationJoinsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  DataTableManufacturerIdAsc = 'DATA_TABLE_MANUFACTURER_ID_ASC',
+  DataTableManufacturerIdDesc = 'DATA_TABLE_MANUFACTURER_ID_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTableManufacturerApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableManufacturerApplicationJoinCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dataTableManufacturerId` field. */
+  dataTableManufacturerId?: Maybe<Scalars['Int']>;
+};
+
+/** A connection to a list of `DataTableManufacturerApplicationJoin` values. */
+export type DataTableManufacturerApplicationJoinsConnection = {
+  __typename?: 'DataTableManufacturerApplicationJoinsConnection';
+  /** A list of `DataTableManufacturerApplicationJoin` objects. */
+  nodes: Array<Maybe<DataTableManufacturerApplicationJoin>>;
+  /** A list of edges which contains the `DataTableManufacturerApplicationJoin` and cursor to aid in pagination. */
+  edges: Array<DataTableManufacturerApplicationJoinsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTableManufacturerApplicationJoin` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTableManufacturerApplicationJoin = Node & {
+  __typename?: 'DataTableManufacturerApplicationJoin';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  applicationId: Scalars['Int'];
+  dataTableManufacturerId: Scalars['Int'];
+  /** Reads a single `Application` that is related to this `DataTableManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturer` that is related to this `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+};
+
+export type DataTableManufacturer = Node & {
+  __typename?: 'DataTableManufacturer';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  manufacturer?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  isAdditional?: Maybe<Scalars['Boolean']>;
+  /** Reads and enables pagination through a set of `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturerApplicationJoins: DataTableManufacturerApplicationJoinsConnection;
+};
+
+
+export type DataTableManufacturerDataTableManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerApplicationJoinFilter>;
+};
+
+/** A `DataTableManufacturerApplicationJoin` edge in the connection. */
+export type DataTableManufacturerApplicationJoinsEdge = {
+  __typename?: 'DataTableManufacturerApplicationJoinsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableManufacturerApplicationJoin` at the end of the edge. */
+  node?: Maybe<DataTableManufacturerApplicationJoin>;
+};
+
+/** Methods to use when ordering `DataTableManufacturerRepresentativeApplicationJoin`. */
+export enum DataTableManufacturerRepresentativeApplicationJoinsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  DataTableManufacturerRepresentativeIdAsc = 'DATA_TABLE_MANUFACTURER_REPRESENTATIVE_ID_ASC',
+  DataTableManufacturerRepresentativeIdDesc = 'DATA_TABLE_MANUFACTURER_REPRESENTATIVE_ID_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTableManufacturerRepresentativeApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableManufacturerRepresentativeApplicationJoinCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dataTableManufacturerRepresentativeId` field. */
+  dataTableManufacturerRepresentativeId?: Maybe<Scalars['Int']>;
+};
+
+/** A connection to a list of `DataTableManufacturerRepresentativeApplicationJoin` values. */
+export type DataTableManufacturerRepresentativeApplicationJoinsConnection = {
+  __typename?: 'DataTableManufacturerRepresentativeApplicationJoinsConnection';
+  /** A list of `DataTableManufacturerRepresentativeApplicationJoin` objects. */
+  nodes: Array<Maybe<DataTableManufacturerRepresentativeApplicationJoin>>;
+  /** A list of edges which contains the `DataTableManufacturerRepresentativeApplicationJoin` and cursor to aid in pagination. */
+  edges: Array<DataTableManufacturerRepresentativeApplicationJoinsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTableManufacturerRepresentativeApplicationJoin` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTableManufacturerRepresentativeApplicationJoin = Node & {
+  __typename?: 'DataTableManufacturerRepresentativeApplicationJoin';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  applicationId: Scalars['Int'];
+  dataTableManufacturerRepresentativeId: Scalars['Int'];
+  /** Reads a single `Application` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturerRepresentative` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+};
+
+export type DataTableManufacturerRepresentative = Node & {
+  __typename?: 'DataTableManufacturerRepresentative';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  evaluationNotes?: Maybe<Scalars['String']>;
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+  /** Reads and enables pagination through a set of `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentativeApplicationJoins: DataTableManufacturerRepresentativeApplicationJoinsConnection;
+};
+
+
+export type DataTableManufacturerRepresentativeDataTableManufacturerRepresentativeApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableManufacturerRepresentativeApplicationJoinCondition>;
+  filter?: Maybe<DataTableManufacturerRepresentativeApplicationJoinFilter>;
+};
+
+/** A `DataTableManufacturerRepresentativeApplicationJoin` edge in the connection. */
+export type DataTableManufacturerRepresentativeApplicationJoinsEdge = {
+  __typename?: 'DataTableManufacturerRepresentativeApplicationJoinsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableManufacturerRepresentativeApplicationJoin` at the end of the edge. */
+  node?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+};
+
+/** Methods to use when ordering `DataTablePermitChemicalApplicationJoin`. */
+export enum DataTablePermitChemicalApplicationJoinsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  DataTablePermitChemicalIdAsc = 'DATA_TABLE_PERMIT_CHEMICAL_ID_ASC',
+  DataTablePermitChemicalIdDesc = 'DATA_TABLE_PERMIT_CHEMICAL_ID_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTablePermitChemicalApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTablePermitChemicalApplicationJoinCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dataTablePermitChemicalId` field. */
+  dataTablePermitChemicalId?: Maybe<Scalars['Int']>;
+};
+
+/** A connection to a list of `DataTablePermitChemicalApplicationJoin` values. */
+export type DataTablePermitChemicalApplicationJoinsConnection = {
+  __typename?: 'DataTablePermitChemicalApplicationJoinsConnection';
+  /** A list of `DataTablePermitChemicalApplicationJoin` objects. */
+  nodes: Array<Maybe<DataTablePermitChemicalApplicationJoin>>;
+  /** A list of edges which contains the `DataTablePermitChemicalApplicationJoin` and cursor to aid in pagination. */
+  edges: Array<DataTablePermitChemicalApplicationJoinsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTablePermitChemicalApplicationJoin` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTablePermitChemicalApplicationJoin = Node & {
+  __typename?: 'DataTablePermitChemicalApplicationJoin';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  applicationId: Scalars['Int'];
+  dataTablePermitChemicalId: Scalars['Int'];
+  /** Reads a single `Application` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePermitChemical` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+};
+
+export type DataTablePermitChemical = Node & {
+  __typename?: 'DataTablePermitChemical';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  permitNo?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  chemicals?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+  /** Reads and enables pagination through a set of `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemicalApplicationJoins: DataTablePermitChemicalApplicationJoinsConnection;
+};
+
+
+export type DataTablePermitChemicalDataTablePermitChemicalApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePermitChemicalApplicationJoinCondition>;
+  filter?: Maybe<DataTablePermitChemicalApplicationJoinFilter>;
+};
+
+/** A `DataTablePermitChemicalApplicationJoin` edge in the connection. */
+export type DataTablePermitChemicalApplicationJoinsEdge = {
+  __typename?: 'DataTablePermitChemicalApplicationJoinsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTablePermitChemicalApplicationJoin` at the end of the edge. */
+  node?: Maybe<DataTablePermitChemicalApplicationJoin>;
+};
+
+/** Methods to use when ordering `DataTablePrequalManufacturerApplicationJoin`. */
+export enum DataTablePrequalManufacturerApplicationJoinsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  DataTablePrequalManufacturerIdAsc = 'DATA_TABLE_PREQUAL_MANUFACTURER_ID_ASC',
+  DataTablePrequalManufacturerIdDesc = 'DATA_TABLE_PREQUAL_MANUFACTURER_ID_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTablePrequalManufacturerApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTablePrequalManufacturerApplicationJoinCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dataTablePrequalManufacturerId` field. */
+  dataTablePrequalManufacturerId?: Maybe<Scalars['Int']>;
+};
+
+/** A connection to a list of `DataTablePrequalManufacturerApplicationJoin` values. */
+export type DataTablePrequalManufacturerApplicationJoinsConnection = {
+  __typename?: 'DataTablePrequalManufacturerApplicationJoinsConnection';
+  /** A list of `DataTablePrequalManufacturerApplicationJoin` objects. */
+  nodes: Array<Maybe<DataTablePrequalManufacturerApplicationJoin>>;
+  /** A list of edges which contains the `DataTablePrequalManufacturerApplicationJoin` and cursor to aid in pagination. */
+  edges: Array<DataTablePrequalManufacturerApplicationJoinsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTablePrequalManufacturerApplicationJoin` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTablePrequalManufacturerApplicationJoin = Node & {
+  __typename?: 'DataTablePrequalManufacturerApplicationJoin';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  applicationId: Scalars['Int'];
+  dataTablePrequalManufacturerId: Scalars['Int'];
+  /** Reads a single `Application` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePrequalManufacturer` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+};
+
+export type DataTablePrequalManufacturer = Node & {
+  __typename?: 'DataTablePrequalManufacturer';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  lookupId?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  manufacturerId?: Maybe<Scalars['String']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  permitNo?: Maybe<Scalars['String']>;
+  dateIssued?: Maybe<Scalars['String']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  /** Reads and enables pagination through a set of `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturerApplicationJoins: DataTablePrequalManufacturerApplicationJoinsConnection;
+};
+
+
+export type DataTablePrequalManufacturerDataTablePrequalManufacturerApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTablePrequalManufacturerApplicationJoinCondition>;
+  filter?: Maybe<DataTablePrequalManufacturerApplicationJoinFilter>;
+};
+
+/** A `DataTablePrequalManufacturerApplicationJoin` edge in the connection. */
+export type DataTablePrequalManufacturerApplicationJoinsEdge = {
+  __typename?: 'DataTablePrequalManufacturerApplicationJoinsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTablePrequalManufacturerApplicationJoin` at the end of the edge. */
+  node?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
+};
+
 /** Methods to use when ordering `DataTableProductApplicationJoin`. */
 export enum DataTableProductApplicationJoinsOrderBy {
   Natural = 'NATURAL',
@@ -10157,60 +11195,6 @@ export type DataTableProductApplicationJoin = Node & {
   dataTableProductId: Scalars['Int'];
   /** Reads a single `Application` that is related to this `DataTableProductApplicationJoin`. */
   application?: Maybe<Application>;
-  /** Reads a single `DataTableProduct` that is related to this `DataTableProductApplicationJoin`. */
-  dataTableProduct?: Maybe<DataTableProduct>;
-};
-
-export type DataTableProduct = Node & {
-  __typename?: 'DataTableProduct';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  origin?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  expiryDate?: Maybe<Scalars['Datetime']>;
-  registration?: Maybe<Scalars['String']>;
-  applicantName?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  responsiblePerson?: Maybe<Scalars['JSON']>;
-  name?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  atcClass?: Maybe<Scalars['String']>;
-  companyId?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Scalars['JSON']>;
-  dosageForm?: Maybe<Scalars['String']>;
-  applicantId?: Maybe<Scalars['Int']>;
-  companyName?: Maybe<Scalars['String']>;
-  formulations?: Maybe<Scalars['JSON']>;
-  prescription?: Maybe<Scalars['String']>;
-  genericNames?: Maybe<Scalars['JSON']>;
-  medicineType?: Maybe<Scalars['String']>;
-  applicationType?: Maybe<Scalars['String']>;
-  primaryContainer?: Maybe<Scalars['String']>;
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  administrationRoute?: Maybe<Scalars['String']>;
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
-  /** Reads and enables pagination through a set of `DataTableProductApplicationJoin`. */
-  dataTableProductApplicationJoins: DataTableProductApplicationJoinsConnection;
-};
-
-
-export type DataTableProductDataTableProductApplicationJoinsArgs = {
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['Cursor']>;
-  after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<DataTableProductApplicationJoinsOrderBy>>;
-  condition?: Maybe<DataTableProductApplicationJoinCondition>;
-  filter?: Maybe<DataTableProductApplicationJoinFilter>;
 };
 
 /** A `DataTableProductApplicationJoin` edge in the connection. */
@@ -10222,60 +11206,116 @@ export type DataTableProductApplicationJoinsEdge = {
   node?: Maybe<DataTableProductApplicationJoin>;
 };
 
-/** Methods to use when ordering `ProductApplicationJoin`. */
-export enum ProductApplicationJoinsOrderBy {
+/** Methods to use when ordering `DataTableProvisionalProductApplicationJoin`. */
+export enum DataTableProvisionalProductApplicationJoinsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
   ApplicationIdAsc = 'APPLICATION_ID_ASC',
   ApplicationIdDesc = 'APPLICATION_ID_DESC',
-  ProductIdAsc = 'PRODUCT_ID_ASC',
-  ProductIdDesc = 'PRODUCT_ID_DESC',
+  DataTableProvisionalProductIdAsc = 'DATA_TABLE_PROVISIONAL_PRODUCT_ID_ASC',
+  DataTableProvisionalProductIdDesc = 'DATA_TABLE_PROVISIONAL_PRODUCT_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
-/** A condition to be used against `ProductApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type ProductApplicationJoinCondition = {
+/** A condition to be used against `DataTableProvisionalProductApplicationJoin` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableProvisionalProductApplicationJoinCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `applicationId` field. */
   applicationId?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `productId` field. */
-  productId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dataTableProvisionalProductId` field. */
+  dataTableProvisionalProductId?: Maybe<Scalars['Int']>;
 };
 
-/** A connection to a list of `ProductApplicationJoin` values. */
-export type ProductApplicationJoinsConnection = {
-  __typename?: 'ProductApplicationJoinsConnection';
-  /** A list of `ProductApplicationJoin` objects. */
-  nodes: Array<Maybe<ProductApplicationJoin>>;
-  /** A list of edges which contains the `ProductApplicationJoin` and cursor to aid in pagination. */
-  edges: Array<ProductApplicationJoinsEdge>;
+/** A connection to a list of `DataTableProvisionalProductApplicationJoin` values. */
+export type DataTableProvisionalProductApplicationJoinsConnection = {
+  __typename?: 'DataTableProvisionalProductApplicationJoinsConnection';
+  /** A list of `DataTableProvisionalProductApplicationJoin` objects. */
+  nodes: Array<Maybe<DataTableProvisionalProductApplicationJoin>>;
+  /** A list of edges which contains the `DataTableProvisionalProductApplicationJoin` and cursor to aid in pagination. */
+  edges: Array<DataTableProvisionalProductApplicationJoinsEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
-  /** The count of *all* `ProductApplicationJoin` you could get from the connection. */
+  /** The count of *all* `DataTableProvisionalProductApplicationJoin` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
 
-export type ProductApplicationJoin = Node & {
-  __typename?: 'ProductApplicationJoin';
+export type DataTableProvisionalProductApplicationJoin = Node & {
+  __typename?: 'DataTableProvisionalProductApplicationJoin';
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
   applicationId: Scalars['Int'];
-  productId: Scalars['Int'];
-  /** Reads a single `Application` that is related to this `ProductApplicationJoin`. */
+  dataTableProvisionalProductId: Scalars['Int'];
+  /** Reads a single `Application` that is related to this `DataTableProvisionalProductApplicationJoin`. */
   application?: Maybe<Application>;
+  /** Reads a single `DataTableProvisionalProduct` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
 };
 
-/** A `ProductApplicationJoin` edge in the connection. */
-export type ProductApplicationJoinsEdge = {
-  __typename?: 'ProductApplicationJoinsEdge';
+export type DataTableProvisionalProduct = Node & {
+  __typename?: 'DataTableProvisionalProduct';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  fullName?: Maybe<Scalars['String']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  productId?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  originalId?: Maybe<Scalars['String']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  registeredIn?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  atcCode?: Maybe<Scalars['JSON']>;
+  pharmacopeia?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  prequalified?: Maybe<Scalars['Boolean']>;
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  loaSource?: Maybe<Scalars['String']>;
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
+  /** Reads and enables pagination through a set of `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProductApplicationJoins: DataTableProvisionalProductApplicationJoinsConnection;
+};
+
+
+export type DataTableProvisionalProductDataTableProvisionalProductApplicationJoinsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+  condition?: Maybe<DataTableProvisionalProductApplicationJoinCondition>;
+  filter?: Maybe<DataTableProvisionalProductApplicationJoinFilter>;
+};
+
+/** A `DataTableProvisionalProductApplicationJoin` edge in the connection. */
+export type DataTableProvisionalProductApplicationJoinsEdge = {
+  __typename?: 'DataTableProvisionalProductApplicationJoinsEdge';
   /** A cursor for use in pagination. */
   cursor?: Maybe<Scalars['Cursor']>;
-  /** The `ProductApplicationJoin` at the end of the edge. */
-  node?: Maybe<ProductApplicationJoin>;
+  /** The `DataTableProvisionalProductApplicationJoin` at the end of the edge. */
+  node?: Maybe<DataTableProvisionalProductApplicationJoin>;
 };
 
 /** Methods to use when ordering `TriggerQueue`. */
@@ -10587,22 +11627,6 @@ export type ApplicationListShapeCondition = {
   assignerAction?: Maybe<AssignerAction>;
 };
 
-export enum ReviewerAction {
-  SelfAssign = 'SELF_ASSIGN',
-  StartReview = 'START_REVIEW',
-  ViewReview = 'VIEW_REVIEW',
-  ContinueReview = 'CONTINUE_REVIEW',
-  MakeDecision = 'MAKE_DECISION',
-  RestartReview = 'RESTART_REVIEW',
-  UpdateReview = 'UPDATE_REVIEW',
-  AwaitingResponse = 'AWAITING_RESPONSE'
-}
-
-export enum AssignerAction {
-  Assign = 'ASSIGN',
-  ReAssign = 'RE_ASSIGN'
-}
-
 /** A filter to be used against `ApplicationListShape` object types. All fields are combined with a logical ‘and.’ */
 export type ApplicationListShapeFilter = {
   /** Filter by the object’s `id` field. */
@@ -10645,58 +11669,6 @@ export type ApplicationListShapeFilter = {
   or?: Maybe<Array<ApplicationListShapeFilter>>;
   /** Negates the expression. */
   not?: Maybe<ApplicationListShapeFilter>;
-};
-
-/** A filter to be used against ReviewerAction fields. All fields are combined with a logical ‘and.’ */
-export type ReviewerActionFilter = {
-  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
-  isNull?: Maybe<Scalars['Boolean']>;
-  /** Equal to the specified value. */
-  equalTo?: Maybe<ReviewerAction>;
-  /** Not equal to the specified value. */
-  notEqualTo?: Maybe<ReviewerAction>;
-  /** Not equal to the specified value, treating null like an ordinary value. */
-  distinctFrom?: Maybe<ReviewerAction>;
-  /** Equal to the specified value, treating null like an ordinary value. */
-  notDistinctFrom?: Maybe<ReviewerAction>;
-  /** Included in the specified list. */
-  in?: Maybe<Array<ReviewerAction>>;
-  /** Not included in the specified list. */
-  notIn?: Maybe<Array<ReviewerAction>>;
-  /** Less than the specified value. */
-  lessThan?: Maybe<ReviewerAction>;
-  /** Less than or equal to the specified value. */
-  lessThanOrEqualTo?: Maybe<ReviewerAction>;
-  /** Greater than the specified value. */
-  greaterThan?: Maybe<ReviewerAction>;
-  /** Greater than or equal to the specified value. */
-  greaterThanOrEqualTo?: Maybe<ReviewerAction>;
-};
-
-/** A filter to be used against AssignerAction fields. All fields are combined with a logical ‘and.’ */
-export type AssignerActionFilter = {
-  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
-  isNull?: Maybe<Scalars['Boolean']>;
-  /** Equal to the specified value. */
-  equalTo?: Maybe<AssignerAction>;
-  /** Not equal to the specified value. */
-  notEqualTo?: Maybe<AssignerAction>;
-  /** Not equal to the specified value, treating null like an ordinary value. */
-  distinctFrom?: Maybe<AssignerAction>;
-  /** Equal to the specified value, treating null like an ordinary value. */
-  notDistinctFrom?: Maybe<AssignerAction>;
-  /** Included in the specified list. */
-  in?: Maybe<Array<AssignerAction>>;
-  /** Not included in the specified list. */
-  notIn?: Maybe<Array<AssignerAction>>;
-  /** Less than the specified value. */
-  lessThan?: Maybe<AssignerAction>;
-  /** Less than or equal to the specified value. */
-  lessThanOrEqualTo?: Maybe<AssignerAction>;
-  /** Greater than the specified value. */
-  greaterThan?: Maybe<AssignerAction>;
-  /** Greater than or equal to the specified value. */
-  greaterThanOrEqualTo?: Maybe<AssignerAction>;
 };
 
 /** A connection to a list of `ApplicationListShape` values. */
@@ -11612,83 +12584,6 @@ export type DataTablesEdge = {
   node?: Maybe<DataTable>;
 };
 
-/** Methods to use when ordering `DataTableManufacturingStep`. */
-export enum DataTableManufacturingStepsOrderBy {
-  Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  TipoDeFabricanteAsc = 'TIPO_DE_FABRICANTE_ASC',
-  TipoDeFabricanteDesc = 'TIPO_DE_FABRICANTE_DESC',
-  ManufacturingOperationAsc = 'MANUFACTURING_OPERATION_ASC',
-  ManufacturingOperationDesc = 'MANUFACTURING_OPERATION_DESC',
-  DefinitionAsc = 'DEFINITION_ASC',
-  DefinitionDesc = 'DEFINITION_DESC',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
-/** A condition to be used against `DataTableManufacturingStep` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableManufacturingStepCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `tipoDeFabricante` field. */
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `manufacturingOperation` field. */
-  manufacturingOperation?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `definition` field. */
-  definition?: Maybe<Scalars['String']>;
-};
-
-/** A filter to be used against `DataTableManufacturingStep` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableManufacturingStepFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `tipoDeFabricante` field. */
-  tipoDeFabricante?: Maybe<StringFilter>;
-  /** Filter by the object’s `manufacturingOperation` field. */
-  manufacturingOperation?: Maybe<StringFilter>;
-  /** Filter by the object’s `definition` field. */
-  definition?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableManufacturingStepFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableManufacturingStepFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableManufacturingStepFilter>;
-};
-
-/** A connection to a list of `DataTableManufacturingStep` values. */
-export type DataTableManufacturingStepsConnection = {
-  __typename?: 'DataTableManufacturingStepsConnection';
-  /** A list of `DataTableManufacturingStep` objects. */
-  nodes: Array<Maybe<DataTableManufacturingStep>>;
-  /** A list of edges which contains the `DataTableManufacturingStep` and cursor to aid in pagination. */
-  edges: Array<DataTableManufacturingStepsEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `DataTableManufacturingStep` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-export type DataTableManufacturingStep = Node & {
-  __typename?: 'DataTableManufacturingStep';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
-  definition?: Maybe<Scalars['String']>;
-};
-
-/** A `DataTableManufacturingStep` edge in the connection. */
-export type DataTableManufacturingStepsEdge = {
-  __typename?: 'DataTableManufacturingStepsEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableManufacturingStep` at the end of the edge. */
-  node?: Maybe<DataTableManufacturingStep>;
-};
-
 /** Methods to use when ordering `DataTableActiveIngredient`. */
 export enum DataTableActiveIngredientsOrderBy {
   Natural = 'NATURAL',
@@ -11698,8 +12593,6 @@ export enum DataTableActiveIngredientsOrderBy {
   NameDesc = 'NAME_DESC',
   LatinaAsc = 'LATINA_ASC',
   LatinaDesc = 'LATINA_DESC',
-  PortugueseAsc = 'PORTUGUESE_ASC',
-  PortugueseDesc = 'PORTUGUESE_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -11712,8 +12605,6 @@ export type DataTableActiveIngredientCondition = {
   name?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `latina` field. */
   latina?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `portuguese` field. */
-  portuguese?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableActiveIngredient` object types. All fields are combined with a logical ‘and.’ */
@@ -11724,8 +12615,6 @@ export type DataTableActiveIngredientFilter = {
   name?: Maybe<StringFilter>;
   /** Filter by the object’s `latina` field. */
   latina?: Maybe<StringFilter>;
-  /** Filter by the object’s `portuguese` field. */
-  portuguese?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableActiveIngredientFilter>>;
   /** Checks for any expressions in this list. */
@@ -11754,7 +12643,6 @@ export type DataTableActiveIngredient = Node & {
   id: Scalars['Int'];
   name?: Maybe<Scalars['String']>;
   latina?: Maybe<Scalars['String']>;
-  portuguese?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableActiveIngredient` edge in the connection. */
@@ -11773,8 +12661,10 @@ export enum DataTableAdministrationRoutesOrderBy {
   IdDesc = 'ID_DESC',
   CodeAsc = 'CODE_ASC',
   CodeDesc = 'CODE_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
+  LongDescriptionAsc = 'LONG_DESCRIPTION_ASC',
+  LongDescriptionDesc = 'LONG_DESCRIPTION_DESC',
+  ShortDescriptionAsc = 'SHORT_DESCRIPTION_ASC',
+  ShortDescriptionDesc = 'SHORT_DESCRIPTION_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -11785,8 +12675,10 @@ export type DataTableAdministrationRouteCondition = {
   id?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `code` field. */
   code?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `longDescription` field. */
+  longDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `shortDescription` field. */
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableAdministrationRoute` object types. All fields are combined with a logical ‘and.’ */
@@ -11795,8 +12687,10 @@ export type DataTableAdministrationRouteFilter = {
   id?: Maybe<IntFilter>;
   /** Filter by the object’s `code` field. */
   code?: Maybe<StringFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `longDescription` field. */
+  longDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `shortDescription` field. */
+  shortDescription?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableAdministrationRouteFilter>>;
   /** Checks for any expressions in this list. */
@@ -11824,7 +12718,8 @@ export type DataTableAdministrationRoute = Node & {
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableAdministrationRoute` edge in the connection. */
@@ -11841,8 +12736,8 @@ export enum DataTableAnnexesOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  CountryAsc = 'COUNTRY_ASC',
-  CountryDesc = 'COUNTRY_DESC',
+  NameCommonAsc = 'NAME_COMMON_ASC',
+  NameCommonDesc = 'NAME_COMMON_DESC',
   SourceAsc = 'SOURCE_ASC',
   SourceDesc = 'SOURCE_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -11853,8 +12748,8 @@ export enum DataTableAnnexesOrderBy {
 export type DataTableAnnexCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `country` field. */
-  country?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `nameCommon` field. */
+  nameCommon?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `source` field. */
   source?: Maybe<Scalars['String']>;
 };
@@ -11863,8 +12758,8 @@ export type DataTableAnnexCondition = {
 export type DataTableAnnexFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `country` field. */
-  country?: Maybe<StringFilter>;
+  /** Filter by the object’s `nameCommon` field. */
+  nameCommon?: Maybe<StringFilter>;
   /** Filter by the object’s `source` field. */
   source?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
@@ -11893,7 +12788,7 @@ export type DataTableAnnex = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  country?: Maybe<Scalars['String']>;
+  nameCommon?: Maybe<Scalars['String']>;
   source?: Maybe<Scalars['String']>;
 };
 
@@ -12060,90 +12955,6 @@ export type DataTableAtcCodesEdge = {
   node?: Maybe<DataTableAtcCode>;
 };
 
-/** Methods to use when ordering `DataTableAtcTherapeuticCategory`. */
-export enum DataTableAtcTherapeuticCategoriesOrderBy {
-  Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  WhoAtcIdAsc = 'WHO_ATC_ID_ASC',
-  WhoAtcIdDesc = 'WHO_ATC_ID_DESC',
-  AtcCodeAsc = 'ATC_CODE_ASC',
-  AtcCodeDesc = 'ATC_CODE_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
-  CategoryAsc = 'CATEGORY_ASC',
-  CategoryDesc = 'CATEGORY_DESC',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
-/** A condition to be used against `DataTableAtcTherapeuticCategory` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableAtcTherapeuticCategoryCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `whoAtcId` field. */
-  whoAtcId?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `atcCode` field. */
-  atcCode?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `category` field. */
-  category?: Maybe<Scalars['String']>;
-};
-
-/** A filter to be used against `DataTableAtcTherapeuticCategory` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableAtcTherapeuticCategoryFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `whoAtcId` field. */
-  whoAtcId?: Maybe<StringFilter>;
-  /** Filter by the object’s `atcCode` field. */
-  atcCode?: Maybe<StringFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
-  /** Filter by the object’s `category` field. */
-  category?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableAtcTherapeuticCategoryFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableAtcTherapeuticCategoryFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableAtcTherapeuticCategoryFilter>;
-};
-
-/** A connection to a list of `DataTableAtcTherapeuticCategory` values. */
-export type DataTableAtcTherapeuticCategoriesConnection = {
-  __typename?: 'DataTableAtcTherapeuticCategoriesConnection';
-  /** A list of `DataTableAtcTherapeuticCategory` objects. */
-  nodes: Array<Maybe<DataTableAtcTherapeuticCategory>>;
-  /** A list of edges which contains the `DataTableAtcTherapeuticCategory` and cursor to aid in pagination. */
-  edges: Array<DataTableAtcTherapeuticCategoriesEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `DataTableAtcTherapeuticCategory` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-export type DataTableAtcTherapeuticCategory = Node & {
-  __typename?: 'DataTableAtcTherapeuticCategory';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** A `DataTableAtcTherapeuticCategory` edge in the connection. */
-export type DataTableAtcTherapeuticCategoriesEdge = {
-  __typename?: 'DataTableAtcTherapeuticCategoriesEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableAtcTherapeuticCategory` at the end of the edge. */
-  node?: Maybe<DataTableAtcTherapeuticCategory>;
-};
-
 /** Methods to use when ordering `DataTableContainer`. */
 export enum DataTableContainersOrderBy {
   Natural = 'NATURAL',
@@ -12151,8 +12962,10 @@ export enum DataTableContainersOrderBy {
   IdDesc = 'ID_DESC',
   CodeAsc = 'CODE_ASC',
   CodeDesc = 'CODE_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
+  LongDescriptionAsc = 'LONG_DESCRIPTION_ASC',
+  LongDescriptionDesc = 'LONG_DESCRIPTION_DESC',
+  ShortDescriptionAsc = 'SHORT_DESCRIPTION_ASC',
+  ShortDescriptionDesc = 'SHORT_DESCRIPTION_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -12163,8 +12976,10 @@ export type DataTableContainerCondition = {
   id?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `code` field. */
   code?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `longDescription` field. */
+  longDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `shortDescription` field. */
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableContainer` object types. All fields are combined with a logical ‘and.’ */
@@ -12173,8 +12988,10 @@ export type DataTableContainerFilter = {
   id?: Maybe<IntFilter>;
   /** Filter by the object’s `code` field. */
   code?: Maybe<StringFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `longDescription` field. */
+  longDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `shortDescription` field. */
+  shortDescription?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableContainerFilter>>;
   /** Checks for any expressions in this list. */
@@ -12202,7 +13019,8 @@ export type DataTableContainer = Node & {
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableContainer` edge in the connection. */
@@ -12227,8 +13045,6 @@ export enum DataTableCountriesOrderBy {
   TranslationsPorOfficialDesc = 'TRANSLATIONS_POR_OFFICIAL_DESC',
   TranslationsPorCommonAsc = 'TRANSLATIONS_POR_COMMON_ASC',
   TranslationsPorCommonDesc = 'TRANSLATIONS_POR_COMMON_DESC',
-  TranslationCommonNoAccentAsc = 'TRANSLATION_COMMON_NO_ACCENT_ASC',
-  TranslationCommonNoAccentDesc = 'TRANSLATION_COMMON_NO_ACCENT_DESC',
   FlagAsc = 'FLAG_ASC',
   FlagDesc = 'FLAG_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -12247,8 +13063,6 @@ export type DataTableCountryCondition = {
   translationsPorOfficial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `translationsPorCommon` field. */
   translationsPorCommon?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `translationCommonNoAccent` field. */
-  translationCommonNoAccent?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `flag` field. */
   flag?: Maybe<Scalars['String']>;
 };
@@ -12265,8 +13079,6 @@ export type DataTableCountryFilter = {
   translationsPorOfficial?: Maybe<StringFilter>;
   /** Filter by the object’s `translationsPorCommon` field. */
   translationsPorCommon?: Maybe<StringFilter>;
-  /** Filter by the object’s `translationCommonNoAccent` field. */
-  translationCommonNoAccent?: Maybe<StringFilter>;
   /** Filter by the object’s `flag` field. */
   flag?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
@@ -12299,7 +13111,6 @@ export type DataTableCountry = Node & {
   nameOfficial?: Maybe<Scalars['String']>;
   translationsPorOfficial?: Maybe<Scalars['String']>;
   translationsPorCommon?: Maybe<Scalars['String']>;
-  translationCommonNoAccent?: Maybe<Scalars['String']>;
   flag?: Maybe<Scalars['String']>;
 };
 
@@ -12317,8 +13128,12 @@ export enum DataTableDosageFormsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  DosageFormAsc = 'DOSAGE_FORM_ASC',
-  DosageFormDesc = 'DOSAGE_FORM_DESC',
+  CodeAsc = 'CODE_ASC',
+  CodeDesc = 'CODE_DESC',
+  LongDescriptionAsc = 'LONG_DESCRIPTION_ASC',
+  LongDescriptionDesc = 'LONG_DESCRIPTION_DESC',
+  ShortDescriptionAsc = 'SHORT_DESCRIPTION_ASC',
+  ShortDescriptionDesc = 'SHORT_DESCRIPTION_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -12327,16 +13142,24 @@ export enum DataTableDosageFormsOrderBy {
 export type DataTableDosageFormCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `dosageForm` field. */
-  dosageForm?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `code` field. */
+  code?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `longDescription` field. */
+  longDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `shortDescription` field. */
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableDosageForm` object types. All fields are combined with a logical ‘and.’ */
 export type DataTableDosageFormFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `dosageForm` field. */
-  dosageForm?: Maybe<StringFilter>;
+  /** Filter by the object’s `code` field. */
+  code?: Maybe<StringFilter>;
+  /** Filter by the object’s `longDescription` field. */
+  longDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `shortDescription` field. */
+  shortDescription?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableDosageFormFilter>>;
   /** Checks for any expressions in this list. */
@@ -12363,7 +13186,9 @@ export type DataTableDosageForm = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  dosageForm?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableDosageForm` edge in the connection. */
@@ -12373,6 +13198,69 @@ export type DataTableDosageFormsEdge = {
   cursor?: Maybe<Scalars['Cursor']>;
   /** The `DataTableDosageForm` at the end of the edge. */
   node?: Maybe<DataTableDosageForm>;
+};
+
+/** Methods to use when ordering `DataTableDosageFormGroup`. */
+export enum DataTableDosageFormGroupsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  DosageFormGroupsAsc = 'DOSAGE_FORM_GROUPS_ASC',
+  DosageFormGroupsDesc = 'DOSAGE_FORM_GROUPS_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTableDosageFormGroup` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableDosageFormGroupCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `dosageFormGroups` field. */
+  dosageFormGroups?: Maybe<Scalars['String']>;
+};
+
+/** A filter to be used against `DataTableDosageFormGroup` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableDosageFormGroupFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `dosageFormGroups` field. */
+  dosageFormGroups?: Maybe<StringFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableDosageFormGroupFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableDosageFormGroupFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableDosageFormGroupFilter>;
+};
+
+/** A connection to a list of `DataTableDosageFormGroup` values. */
+export type DataTableDosageFormGroupsConnection = {
+  __typename?: 'DataTableDosageFormGroupsConnection';
+  /** A list of `DataTableDosageFormGroup` objects. */
+  nodes: Array<Maybe<DataTableDosageFormGroup>>;
+  /** A list of edges which contains the `DataTableDosageFormGroup` and cursor to aid in pagination. */
+  edges: Array<DataTableDosageFormGroupsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTableDosageFormGroup` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTableDosageFormGroup = Node & {
+  __typename?: 'DataTableDosageFormGroup';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  dosageFormGroups?: Maybe<Scalars['String']>;
+};
+
+/** A `DataTableDosageFormGroup` edge in the connection. */
+export type DataTableDosageFormGroupsEdge = {
+  __typename?: 'DataTableDosageFormGroupsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableDosageFormGroup` at the end of the edge. */
+  node?: Maybe<DataTableDosageFormGroup>;
 };
 
 /** Methods to use when ordering `DataTableGenericIngredient`. */
@@ -12473,167 +13361,6 @@ export type DataTableGenericIngredientsEdge = {
   node?: Maybe<DataTableGenericIngredient>;
 };
 
-/** Methods to use when ordering `DataTableIngredientsList`. */
-export enum DataTableIngredientsListsOrderBy {
-  Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  WhoAtcIdAsc = 'WHO_ATC_ID_ASC',
-  WhoAtcIdDesc = 'WHO_ATC_ID_DESC',
-  AtcCodeAsc = 'ATC_CODE_ASC',
-  AtcCodeDesc = 'ATC_CODE_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
-  CategoryAsc = 'CATEGORY_ASC',
-  CategoryDesc = 'CATEGORY_DESC',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
-/** A condition to be used against `DataTableIngredientsList` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableIngredientsListCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `whoAtcId` field. */
-  whoAtcId?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `atcCode` field. */
-  atcCode?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `category` field. */
-  category?: Maybe<Scalars['String']>;
-};
-
-/** A filter to be used against `DataTableIngredientsList` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableIngredientsListFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `whoAtcId` field. */
-  whoAtcId?: Maybe<StringFilter>;
-  /** Filter by the object’s `atcCode` field. */
-  atcCode?: Maybe<StringFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
-  /** Filter by the object’s `category` field. */
-  category?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableIngredientsListFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableIngredientsListFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableIngredientsListFilter>;
-};
-
-/** A connection to a list of `DataTableIngredientsList` values. */
-export type DataTableIngredientsListsConnection = {
-  __typename?: 'DataTableIngredientsListsConnection';
-  /** A list of `DataTableIngredientsList` objects. */
-  nodes: Array<Maybe<DataTableIngredientsList>>;
-  /** A list of edges which contains the `DataTableIngredientsList` and cursor to aid in pagination. */
-  edges: Array<DataTableIngredientsListsEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `DataTableIngredientsList` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-export type DataTableIngredientsList = Node & {
-  __typename?: 'DataTableIngredientsList';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** A `DataTableIngredientsList` edge in the connection. */
-export type DataTableIngredientsListsEdge = {
-  __typename?: 'DataTableIngredientsListsEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableIngredientsList` at the end of the edge. */
-  node?: Maybe<DataTableIngredientsList>;
-};
-
-/** Methods to use when ordering `DataTableInternationalDiallingPrefix`. */
-export enum DataTableInternationalDiallingPrefixesOrderBy {
-  Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  PrefixAsc = 'PREFIX_ASC',
-  PrefixDesc = 'PREFIX_DESC',
-  CountryAsc = 'COUNTRY_ASC',
-  CountryDesc = 'COUNTRY_DESC',
-  DisplayAsc = 'DISPLAY_ASC',
-  DisplayDesc = 'DISPLAY_DESC',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
-/** A condition to be used against `DataTableInternationalDiallingPrefix` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableInternationalDiallingPrefixCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `prefix` field. */
-  prefix?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `country` field. */
-  country?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `display` field. */
-  display?: Maybe<Scalars['String']>;
-};
-
-/** A filter to be used against `DataTableInternationalDiallingPrefix` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableInternationalDiallingPrefixFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `prefix` field. */
-  prefix?: Maybe<StringFilter>;
-  /** Filter by the object’s `country` field. */
-  country?: Maybe<StringFilter>;
-  /** Filter by the object’s `display` field. */
-  display?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableInternationalDiallingPrefixFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableInternationalDiallingPrefixFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableInternationalDiallingPrefixFilter>;
-};
-
-/** A connection to a list of `DataTableInternationalDiallingPrefix` values. */
-export type DataTableInternationalDiallingPrefixesConnection = {
-  __typename?: 'DataTableInternationalDiallingPrefixesConnection';
-  /** A list of `DataTableInternationalDiallingPrefix` objects. */
-  nodes: Array<Maybe<DataTableInternationalDiallingPrefix>>;
-  /** A list of edges which contains the `DataTableInternationalDiallingPrefix` and cursor to aid in pagination. */
-  edges: Array<DataTableInternationalDiallingPrefixesEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `DataTableInternationalDiallingPrefix` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-export type DataTableInternationalDiallingPrefix = Node & {
-  __typename?: 'DataTableInternationalDiallingPrefix';
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  id: Scalars['Int'];
-  prefix?: Maybe<Scalars['String']>;
-  country?: Maybe<Scalars['String']>;
-  display?: Maybe<Scalars['String']>;
-};
-
-/** A `DataTableInternationalDiallingPrefix` edge in the connection. */
-export type DataTableInternationalDiallingPrefixesEdge = {
-  __typename?: 'DataTableInternationalDiallingPrefixesEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableInternationalDiallingPrefix` at the end of the edge. */
-  node?: Maybe<DataTableInternationalDiallingPrefix>;
-};
-
 /** Methods to use when ordering `DataTableListOfSra`. */
 export enum DataTableListOfSrasOrderBy {
   Natural = 'NATURAL',
@@ -12697,74 +13424,514 @@ export type DataTableListOfSrasEdge = {
   node?: Maybe<DataTableListOfSra>;
 };
 
-/** Methods to use when ordering `DataTableManufacturingStepsSimpler`. */
-export enum DataTableManufacturingStepsSimplersOrderBy {
+/** Methods to use when ordering `DataTableManufacturer`. */
+export enum DataTableManufacturersOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  TipoDeFabricanteAsc = 'TIPO_DE_FABRICANTE_ASC',
-  TipoDeFabricanteDesc = 'TIPO_DE_FABRICANTE_DESC',
-  ManufacturingOperationAsc = 'MANUFACTURING_OPERATION_ASC',
-  ManufacturingOperationDesc = 'MANUFACTURING_OPERATION_DESC',
+  ManufacturerAsc = 'MANUFACTURER_ASC',
+  ManufacturerDesc = 'MANUFACTURER_DESC',
+  CountryAsc = 'COUNTRY_ASC',
+  CountryDesc = 'COUNTRY_DESC',
+  AddressAsc = 'ADDRESS_ASC',
+  AddressDesc = 'ADDRESS_DESC',
+  IsAdditionalAsc = 'IS_ADDITIONAL_ASC',
+  IsAdditionalDesc = 'IS_ADDITIONAL_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
-/** A condition to be used against `DataTableManufacturingStepsSimpler` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableManufacturingStepsSimplerCondition = {
+/** A condition to be used against `DataTableManufacturer` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableManufacturerCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `tipoDeFabricante` field. */
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `manufacturingOperation` field. */
-  manufacturingOperation?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `manufacturer` field. */
+  manufacturer?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `country` field. */
+  country?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `address` field. */
+  address?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `isAdditional` field. */
+  isAdditional?: Maybe<Scalars['Boolean']>;
 };
 
-/** A filter to be used against `DataTableManufacturingStepsSimpler` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableManufacturingStepsSimplerFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `tipoDeFabricante` field. */
-  tipoDeFabricante?: Maybe<StringFilter>;
-  /** Filter by the object’s `manufacturingOperation` field. */
-  manufacturingOperation?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableManufacturingStepsSimplerFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableManufacturingStepsSimplerFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableManufacturingStepsSimplerFilter>;
-};
-
-/** A connection to a list of `DataTableManufacturingStepsSimpler` values. */
-export type DataTableManufacturingStepsSimplersConnection = {
-  __typename?: 'DataTableManufacturingStepsSimplersConnection';
-  /** A list of `DataTableManufacturingStepsSimpler` objects. */
-  nodes: Array<Maybe<DataTableManufacturingStepsSimpler>>;
-  /** A list of edges which contains the `DataTableManufacturingStepsSimpler` and cursor to aid in pagination. */
-  edges: Array<DataTableManufacturingStepsSimplersEdge>;
+/** A connection to a list of `DataTableManufacturer` values. */
+export type DataTableManufacturersConnection = {
+  __typename?: 'DataTableManufacturersConnection';
+  /** A list of `DataTableManufacturer` objects. */
+  nodes: Array<Maybe<DataTableManufacturer>>;
+  /** A list of edges which contains the `DataTableManufacturer` and cursor to aid in pagination. */
+  edges: Array<DataTableManufacturersEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
-  /** The count of *all* `DataTableManufacturingStepsSimpler` you could get from the connection. */
+  /** The count of *all* `DataTableManufacturer` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
 
-export type DataTableManufacturingStepsSimpler = Node & {
-  __typename?: 'DataTableManufacturingStepsSimpler';
+/** A `DataTableManufacturer` edge in the connection. */
+export type DataTableManufacturersEdge = {
+  __typename?: 'DataTableManufacturersEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableManufacturer` at the end of the edge. */
+  node?: Maybe<DataTableManufacturer>;
+};
+
+/** Methods to use when ordering `DataTableManufacturerRepresentative`. */
+export enum DataTableManufacturerRepresentativesOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  IsActiveAsc = 'IS_ACTIVE_ASC',
+  IsActiveDesc = 'IS_ACTIVE_DESC',
+  PrequalificationDateAsc = 'PREQUALIFICATION_DATE_ASC',
+  PrequalificationDateDesc = 'PREQUALIFICATION_DATE_DESC',
+  ManufacturerDatabaseIdAsc = 'MANUFACTURER_DATABASE_ID_ASC',
+  ManufacturerDatabaseIdDesc = 'MANUFACTURER_DATABASE_ID_DESC',
+  ManufacturerRegistrationIdAsc = 'MANUFACTURER_REGISTRATION_ID_ASC',
+  ManufacturerRegistrationIdDesc = 'MANUFACTURER_REGISTRATION_ID_DESC',
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  AddressAsc = 'ADDRESS_ASC',
+  AddressDesc = 'ADDRESS_DESC',
+  CountryAsc = 'COUNTRY_ASC',
+  CountryDesc = 'COUNTRY_DESC',
+  GmpScopeAsc = 'GMP_SCOPE_ASC',
+  GmpScopeDesc = 'GMP_SCOPE_DESC',
+  CompanyIdAsc = 'COMPANY_ID_ASC',
+  CompanyIdDesc = 'COMPANY_ID_DESC',
+  ApplicantIdAsc = 'APPLICANT_ID_ASC',
+  ApplicantIdDesc = 'APPLICANT_ID_DESC',
+  CompanyNameAsc = 'COMPANY_NAME_ASC',
+  CompanyNameDesc = 'COMPANY_NAME_DESC',
+  GmpCertificateAsc = 'GMP_CERTIFICATE_ASC',
+  GmpCertificateDesc = 'GMP_CERTIFICATE_DESC',
+  ManufacturingLicenceAsc = 'MANUFACTURING_LICENCE_ASC',
+  ManufacturingLicenceDesc = 'MANUFACTURING_LICENCE_DESC',
+  LetterOfAuthorizationAsc = 'LETTER_OF_AUTHORIZATION_ASC',
+  LetterOfAuthorizationDesc = 'LETTER_OF_AUTHORIZATION_DESC',
+  ManufacturingCompaniesAsc = 'MANUFACTURING_COMPANIES_ASC',
+  ManufacturingCompaniesDesc = 'MANUFACTURING_COMPANIES_DESC',
+  EvaluationNotesAsc = 'EVALUATION_NOTES_ASC',
+  EvaluationNotesDesc = 'EVALUATION_NOTES_DESC',
+  GmpByWhoCertificateAsc = 'GMP_BY_WHO_CERTIFICATE_ASC',
+  GmpByWhoCertificateDesc = 'GMP_BY_WHO_CERTIFICATE_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTableManufacturerRepresentative` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableManufacturerRepresentativeCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `isActive` field. */
+  isActive?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `prequalificationDate` field. */
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `manufacturerDatabaseId` field. */
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `manufacturerRegistrationId` field. */
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `address` field. */
+  address?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `country` field. */
+  country?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `gmpScope` field. */
+  gmpScope?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `companyId` field. */
+  companyId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `applicantId` field. */
+  applicantId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `companyName` field. */
+  companyName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `gmpCertificate` field. */
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `manufacturingLicence` field. */
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `letterOfAuthorization` field. */
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `manufacturingCompanies` field. */
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `evaluationNotes` field. */
+  evaluationNotes?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `gmpByWhoCertificate` field. */
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+};
+
+/** A connection to a list of `DataTableManufacturerRepresentative` values. */
+export type DataTableManufacturerRepresentativesConnection = {
+  __typename?: 'DataTableManufacturerRepresentativesConnection';
+  /** A list of `DataTableManufacturerRepresentative` objects. */
+  nodes: Array<Maybe<DataTableManufacturerRepresentative>>;
+  /** A list of edges which contains the `DataTableManufacturerRepresentative` and cursor to aid in pagination. */
+  edges: Array<DataTableManufacturerRepresentativesEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTableManufacturerRepresentative` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `DataTableManufacturerRepresentative` edge in the connection. */
+export type DataTableManufacturerRepresentativesEdge = {
+  __typename?: 'DataTableManufacturerRepresentativesEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableManufacturerRepresentative` at the end of the edge. */
+  node?: Maybe<DataTableManufacturerRepresentative>;
+};
+
+/** Methods to use when ordering `DataTablePermitChemical`. */
+export enum DataTablePermitChemicalsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  PermitNoAsc = 'PERMIT_NO_ASC',
+  PermitNoDesc = 'PERMIT_NO_DESC',
+  RegistrationDateAsc = 'REGISTRATION_DATE_ASC',
+  RegistrationDateDesc = 'REGISTRATION_DATE_DESC',
+  ChemicalsAsc = 'CHEMICALS_ASC',
+  ChemicalsDesc = 'CHEMICALS_DESC',
+  CompanyIdAsc = 'COMPANY_ID_ASC',
+  CompanyIdDesc = 'COMPANY_ID_DESC',
+  CompanyNameAsc = 'COMPANY_NAME_ASC',
+  CompanyNameDesc = 'COMPANY_NAME_DESC',
+  ChemicalsFilterDataAsc = 'CHEMICALS_FILTER_DATA_ASC',
+  ChemicalsFilterDataDesc = 'CHEMICALS_FILTER_DATA_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTablePermitChemical` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTablePermitChemicalCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `permitNo` field. */
+  permitNo?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `registrationDate` field. */
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `chemicals` field. */
+  chemicals?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `companyId` field. */
+  companyId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `companyName` field. */
+  companyName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `chemicalsFilterData` field. */
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+};
+
+/** A connection to a list of `DataTablePermitChemical` values. */
+export type DataTablePermitChemicalsConnection = {
+  __typename?: 'DataTablePermitChemicalsConnection';
+  /** A list of `DataTablePermitChemical` objects. */
+  nodes: Array<Maybe<DataTablePermitChemical>>;
+  /** A list of edges which contains the `DataTablePermitChemical` and cursor to aid in pagination. */
+  edges: Array<DataTablePermitChemicalsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTablePermitChemical` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `DataTablePermitChemical` edge in the connection. */
+export type DataTablePermitChemicalsEdge = {
+  __typename?: 'DataTablePermitChemicalsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTablePermitChemical` at the end of the edge. */
+  node?: Maybe<DataTablePermitChemical>;
+};
+
+/** Methods to use when ordering `DataTablePreRegisteredProductsProvisional`. */
+export enum DataTablePreRegisteredProductsProvisionalsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ProductIdOriginalAsc = 'PRODUCT_ID_ORIGINAL_ASC',
+  ProductIdOriginalDesc = 'PRODUCT_ID_ORIGINAL_DESC',
+  ProductIdUniqueAsc = 'PRODUCT_ID_UNIQUE_ASC',
+  ProductIdUniqueDesc = 'PRODUCT_ID_UNIQUE_DESC',
+  AuthorityAsc = 'AUTHORITY_ASC',
+  AuthorityDesc = 'AUTHORITY_DESC',
+  TradeNameAsc = 'TRADE_NAME_ASC',
+  TradeNameDesc = 'TRADE_NAME_DESC',
+  FullNameAsc = 'FULL_NAME_ASC',
+  FullNameDesc = 'FULL_NAME_DESC',
+  SponsorNameAsc = 'SPONSOR_NAME_ASC',
+  SponsorNameDesc = 'SPONSOR_NAME_DESC',
+  ActiveIngredientsAsc = 'ACTIVE_INGREDIENTS_ASC',
+  ActiveIngredientsDesc = 'ACTIVE_INGREDIENTS_DESC',
+  ActiveIngredientsResponseAsc = 'ACTIVE_INGREDIENTS_RESPONSE_ASC',
+  ActiveIngredientsResponseDesc = 'ACTIVE_INGREDIENTS_RESPONSE_DESC',
+  MultipleFormulationsAsc = 'MULTIPLE_FORMULATIONS_ASC',
+  MultipleFormulationsDesc = 'MULTIPLE_FORMULATIONS_DESC',
+  ComponentsOriginalAsc = 'COMPONENTS_ORIGINAL_ASC',
+  ComponentsOriginalDesc = 'COMPONENTS_ORIGINAL_DESC',
+  PackSizesAsc = 'PACK_SIZES_ASC',
+  PackSizesDesc = 'PACK_SIZES_DESC',
+  PackSizesResponseAsc = 'PACK_SIZES_RESPONSE_ASC',
+  PackSizesResponseDesc = 'PACK_SIZES_RESPONSE_DESC',
+  ShelfLifeAsc = 'SHELF_LIFE_ASC',
+  ShelfLifeDesc = 'SHELF_LIFE_DESC',
+  StorageConditionsAsc = 'STORAGE_CONDITIONS_ASC',
+  StorageConditionsDesc = 'STORAGE_CONDITIONS_DESC',
+  DosageFormAsc = 'DOSAGE_FORM_ASC',
+  DosageFormDesc = 'DOSAGE_FORM_DESC',
+  RouteOfAdministrationAsc = 'ROUTE_OF_ADMINISTRATION_ASC',
+  RouteOfAdministrationDesc = 'ROUTE_OF_ADMINISTRATION_DESC',
+  IndicationsAsc = 'INDICATIONS_ASC',
+  IndicationsDesc = 'INDICATIONS_DESC',
+  ProductTypeAsc = 'PRODUCT_TYPE_ASC',
+  ProductTypeDesc = 'PRODUCT_TYPE_DESC',
+  ContainerTypeAsc = 'CONTAINER_TYPE_ASC',
+  ContainerTypeDesc = 'CONTAINER_TYPE_DESC',
+  EffectiveDateAsc = 'EFFECTIVE_DATE_ASC',
+  EffectiveDateDesc = 'EFFECTIVE_DATE_DESC',
+  ManufacturersAsc = 'MANUFACTURERS_ASC',
+  ManufacturersDesc = 'MANUFACTURERS_DESC',
+  ManufacturersResponseAsc = 'MANUFACTURERS_RESPONSE_ASC',
+  ManufacturersResponseDesc = 'MANUFACTURERS_RESPONSE_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTablePreRegisteredProductsProvisional` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTablePreRegisteredProductsProvisionalCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `productIdOriginal` field. */
+  productIdOriginal?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `productIdUnique` field. */
+  productIdUnique?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `authority` field. */
+  authority?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `tradeName` field. */
+  tradeName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `fullName` field. */
+  fullName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `sponsorName` field. */
+  sponsorName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `activeIngredients` field. */
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `activeIngredientsResponse` field. */
+  activeIngredientsResponse?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `multipleFormulations` field. */
+  multipleFormulations?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `componentsOriginal` field. */
+  componentsOriginal?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `packSizes` field. */
+  packSizes?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `packSizesResponse` field. */
+  packSizesResponse?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `shelfLife` field. */
+  shelfLife?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `storageConditions` field. */
+  storageConditions?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `dosageForm` field. */
+  dosageForm?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `indications` field. */
+  indications?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `productType` field. */
+  productType?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `containerType` field. */
+  containerType?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `effectiveDate` field. */
+  effectiveDate?: Maybe<Scalars['Date']>;
+  /** Checks for equality with the object’s `manufacturers` field. */
+  manufacturers?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `manufacturersResponse` field. */
+  manufacturersResponse?: Maybe<Scalars['JSON']>;
+};
+
+/** A filter to be used against `DataTablePreRegisteredProductsProvisional` object types. All fields are combined with a logical ‘and.’ */
+export type DataTablePreRegisteredProductsProvisionalFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `productIdOriginal` field. */
+  productIdOriginal?: Maybe<StringFilter>;
+  /** Filter by the object’s `productIdUnique` field. */
+  productIdUnique?: Maybe<StringFilter>;
+  /** Filter by the object’s `authority` field. */
+  authority?: Maybe<StringFilter>;
+  /** Filter by the object’s `tradeName` field. */
+  tradeName?: Maybe<StringFilter>;
+  /** Filter by the object’s `fullName` field. */
+  fullName?: Maybe<StringFilter>;
+  /** Filter by the object’s `sponsorName` field. */
+  sponsorName?: Maybe<StringFilter>;
+  /** Filter by the object’s `activeIngredients` field. */
+  activeIngredients?: Maybe<JsonFilter>;
+  /** Filter by the object’s `activeIngredientsResponse` field. */
+  activeIngredientsResponse?: Maybe<JsonFilter>;
+  /** Filter by the object’s `multipleFormulations` field. */
+  multipleFormulations?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `componentsOriginal` field. */
+  componentsOriginal?: Maybe<JsonFilter>;
+  /** Filter by the object’s `packSizes` field. */
+  packSizes?: Maybe<JsonFilter>;
+  /** Filter by the object’s `packSizesResponse` field. */
+  packSizesResponse?: Maybe<JsonFilter>;
+  /** Filter by the object’s `shelfLife` field. */
+  shelfLife?: Maybe<StringFilter>;
+  /** Filter by the object’s `storageConditions` field. */
+  storageConditions?: Maybe<StringFilter>;
+  /** Filter by the object’s `dosageForm` field. */
+  dosageForm?: Maybe<StringFilter>;
+  /** Filter by the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<StringFilter>;
+  /** Filter by the object’s `indications` field. */
+  indications?: Maybe<StringFilter>;
+  /** Filter by the object’s `productType` field. */
+  productType?: Maybe<StringFilter>;
+  /** Filter by the object’s `containerType` field. */
+  containerType?: Maybe<StringFilter>;
+  /** Filter by the object’s `effectiveDate` field. */
+  effectiveDate?: Maybe<DateFilter>;
+  /** Filter by the object’s `manufacturers` field. */
+  manufacturers?: Maybe<JsonFilter>;
+  /** Filter by the object’s `manufacturersResponse` field. */
+  manufacturersResponse?: Maybe<JsonFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTablePreRegisteredProductsProvisionalFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTablePreRegisteredProductsProvisionalFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTablePreRegisteredProductsProvisionalFilter>;
+};
+
+/** A connection to a list of `DataTablePreRegisteredProductsProvisional` values. */
+export type DataTablePreRegisteredProductsProvisionalsConnection = {
+  __typename?: 'DataTablePreRegisteredProductsProvisionalsConnection';
+  /** A list of `DataTablePreRegisteredProductsProvisional` objects. */
+  nodes: Array<Maybe<DataTablePreRegisteredProductsProvisional>>;
+  /** A list of edges which contains the `DataTablePreRegisteredProductsProvisional` and cursor to aid in pagination. */
+  edges: Array<DataTablePreRegisteredProductsProvisionalsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTablePreRegisteredProductsProvisional` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTablePreRegisteredProductsProvisional = Node & {
+  __typename?: 'DataTablePreRegisteredProductsProvisional';
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
+  productIdOriginal?: Maybe<Scalars['String']>;
+  productIdUnique?: Maybe<Scalars['String']>;
+  authority?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  activeIngredientsResponse?: Maybe<Scalars['JSON']>;
+  multipleFormulations?: Maybe<Scalars['Boolean']>;
+  componentsOriginal?: Maybe<Scalars['JSON']>;
+  packSizes?: Maybe<Scalars['JSON']>;
+  packSizesResponse?: Maybe<Scalars['JSON']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  indications?: Maybe<Scalars['String']>;
+  productType?: Maybe<Scalars['String']>;
+  containerType?: Maybe<Scalars['String']>;
+  effectiveDate?: Maybe<Scalars['Date']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  manufacturersResponse?: Maybe<Scalars['JSON']>;
 };
 
-/** A `DataTableManufacturingStepsSimpler` edge in the connection. */
-export type DataTableManufacturingStepsSimplersEdge = {
-  __typename?: 'DataTableManufacturingStepsSimplersEdge';
+/** A `DataTablePreRegisteredProductsProvisional` edge in the connection. */
+export type DataTablePreRegisteredProductsProvisionalsEdge = {
+  __typename?: 'DataTablePreRegisteredProductsProvisionalsEdge';
   /** A cursor for use in pagination. */
   cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableManufacturingStepsSimpler` at the end of the edge. */
-  node?: Maybe<DataTableManufacturingStepsSimpler>;
+  /** The `DataTablePreRegisteredProductsProvisional` at the end of the edge. */
+  node?: Maybe<DataTablePreRegisteredProductsProvisional>;
+};
+
+/** Methods to use when ordering `DataTablePrequalManufacturer`. */
+export enum DataTablePrequalManufacturersOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  LookupIdAsc = 'LOOKUP_ID_ASC',
+  LookupIdDesc = 'LOOKUP_ID_DESC',
+  IsActiveAsc = 'IS_ACTIVE_ASC',
+  IsActiveDesc = 'IS_ACTIVE_DESC',
+  ManufacturerIdAsc = 'MANUFACTURER_ID_ASC',
+  ManufacturerIdDesc = 'MANUFACTURER_ID_DESC',
+  PrequalificationDateAsc = 'PREQUALIFICATION_DATE_ASC',
+  PrequalificationDateDesc = 'PREQUALIFICATION_DATE_DESC',
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  AddressAsc = 'ADDRESS_ASC',
+  AddressDesc = 'ADDRESS_DESC',
+  CountryAsc = 'COUNTRY_ASC',
+  CountryDesc = 'COUNTRY_DESC',
+  GmpScopeAsc = 'GMP_SCOPE_ASC',
+  GmpScopeDesc = 'GMP_SCOPE_DESC',
+  PermitNoAsc = 'PERMIT_NO_ASC',
+  PermitNoDesc = 'PERMIT_NO_DESC',
+  DateIssuedAsc = 'DATE_ISSUED_ASC',
+  DateIssuedDesc = 'DATE_ISSUED_DESC',
+  ManufacturingLicenceAsc = 'MANUFACTURING_LICENCE_ASC',
+  ManufacturingLicenceDesc = 'MANUFACTURING_LICENCE_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTablePrequalManufacturer` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTablePrequalManufacturerCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `lookupId` field. */
+  lookupId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `isActive` field. */
+  isActive?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `manufacturerId` field. */
+  manufacturerId?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `prequalificationDate` field. */
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `address` field. */
+  address?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `country` field. */
+  country?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `gmpScope` field. */
+  gmpScope?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `permitNo` field. */
+  permitNo?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `dateIssued` field. */
+  dateIssued?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `manufacturingLicence` field. */
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+};
+
+/** A connection to a list of `DataTablePrequalManufacturer` values. */
+export type DataTablePrequalManufacturersConnection = {
+  __typename?: 'DataTablePrequalManufacturersConnection';
+  /** A list of `DataTablePrequalManufacturer` objects. */
+  nodes: Array<Maybe<DataTablePrequalManufacturer>>;
+  /** A list of edges which contains the `DataTablePrequalManufacturer` and cursor to aid in pagination. */
+  edges: Array<DataTablePrequalManufacturersEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTablePrequalManufacturer` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `DataTablePrequalManufacturer` edge in the connection. */
+export type DataTablePrequalManufacturersEdge = {
+  __typename?: 'DataTablePrequalManufacturersEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTablePrequalManufacturer` at the end of the edge. */
+  node?: Maybe<DataTablePrequalManufacturer>;
 };
 
 /** Methods to use when ordering `DataTableProcessingStep`. */
@@ -12772,10 +13939,8 @@ export enum DataTableProcessingStepsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
-  PortugueseNameAsc = 'PORTUGUESE_NAME_ASC',
-  PortugueseNameDesc = 'PORTUGUESE_NAME_DESC',
+  ProcessingStepAsc = 'PROCESSING_STEP_ASC',
+  ProcessingStepDesc = 'PROCESSING_STEP_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -12784,20 +13949,16 @@ export enum DataTableProcessingStepsOrderBy {
 export type DataTableProcessingStepCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `portugueseName` field. */
-  portugueseName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `processingStep` field. */
+  processingStep?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableProcessingStep` object types. All fields are combined with a logical ‘and.’ */
 export type DataTableProcessingStepFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
-  /** Filter by the object’s `portugueseName` field. */
-  portugueseName?: Maybe<StringFilter>;
+  /** Filter by the object’s `processingStep` field. */
+  processingStep?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableProcessingStepFilter>>;
   /** Checks for any expressions in this list. */
@@ -12824,8 +13985,7 @@ export type DataTableProcessingStep = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  processingStep?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableProcessingStep` edge in the connection. */
@@ -12842,68 +14002,64 @@ export enum DataTableProductsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  OriginAsc = 'ORIGIN_ASC',
-  OriginDesc = 'ORIGIN_DESC',
-  IsActiveAsc = 'IS_ACTIVE_ASC',
-  IsActiveDesc = 'IS_ACTIVE_DESC',
   ExpiryDateAsc = 'EXPIRY_DATE_ASC',
   ExpiryDateDesc = 'EXPIRY_DATE_DESC',
-  RegistrationAsc = 'REGISTRATION_ASC',
-  RegistrationDesc = 'REGISTRATION_DESC',
-  ApplicantNameAsc = 'APPLICANT_NAME_ASC',
-  ApplicantNameDesc = 'APPLICANT_NAME_DESC',
+  ProductOriginAsc = 'PRODUCT_ORIGIN_ASC',
+  ProductOriginDesc = 'PRODUCT_ORIGIN_DESC',
   RegistrationDateAsc = 'REGISTRATION_DATE_ASC',
   RegistrationDateDesc = 'REGISTRATION_DATE_DESC',
-  ResponsiblePersonAsc = 'RESPONSIBLE_PERSON_ASC',
-  ResponsiblePersonDesc = 'RESPONSIBLE_PERSON_DESC',
+  RegistrationSerialAsc = 'REGISTRATION_SERIAL_ASC',
+  RegistrationSerialDesc = 'REGISTRATION_SERIAL_DESC',
+  SraAsc = 'SRA_ASC',
+  SraDesc = 'SRA_DESC',
   NameAsc = 'NAME_ASC',
   NameDesc = 'NAME_DESC',
   AtcCodeAsc = 'ATC_CODE_ASC',
   AtcCodeDesc = 'ATC_CODE_DESC',
-  AtcClassAsc = 'ATC_CLASS_ASC',
-  AtcClassDesc = 'ATC_CLASS_DESC',
-  CompanyIdAsc = 'COMPANY_ID_ASC',
-  CompanyIdDesc = 'COMPANY_ID_DESC',
-  DimensionsAsc = 'DIMENSIONS_ASC',
-  DimensionsDesc = 'DIMENSIONS_DESC',
+  ShelfLifeAsc = 'SHELF_LIFE_ASC',
+  ShelfLifeDesc = 'SHELF_LIFE_DESC',
   DosageFormAsc = 'DOSAGE_FORM_ASC',
   DosageFormDesc = 'DOSAGE_FORM_DESC',
-  ApplicantIdAsc = 'APPLICANT_ID_ASC',
-  ApplicantIdDesc = 'APPLICANT_ID_DESC',
+  AtcCategoryAsc = 'ATC_CATEGORY_ASC',
+  AtcCategoryDesc = 'ATC_CATEGORY_DESC',
   CompanyNameAsc = 'COMPANY_NAME_ASC',
   CompanyNameDesc = 'COMPANY_NAME_DESC',
   FormulationsAsc = 'FORMULATIONS_ASC',
   FormulationsDesc = 'FORMULATIONS_DESC',
-  PrescriptionAsc = 'PRESCRIPTION_ASC',
-  PrescriptionDesc = 'PRESCRIPTION_DESC',
-  GenericNamesAsc = 'GENERIC_NAMES_ASC',
-  GenericNamesDesc = 'GENERIC_NAMES_DESC',
-  MedicineTypeAsc = 'MEDICINE_TYPE_ASC',
-  MedicineTypeDesc = 'MEDICINE_TYPE_DESC',
-  ApplicationTypeAsc = 'APPLICATION_TYPE_ASC',
-  ApplicationTypeDesc = 'APPLICATION_TYPE_DESC',
+  CompanyPhoneAsc = 'COMPANY_PHONE_ASC',
+  CompanyPhoneDesc = 'COMPANY_PHONE_DESC',
+  CompanyAddressAsc = 'COMPANY_ADDRESS_ASC',
+  CompanyAddressDesc = 'COMPANY_ADDRESS_DESC',
+  PackagingSizesAsc = 'PACKAGING_SIZES_ASC',
+  PackagingSizesDesc = 'PACKAGING_SIZES_DESC',
+  ImporterAddressAsc = 'IMPORTER_ADDRESS_ASC',
+  ImporterAddressDesc = 'IMPORTER_ADDRESS_DESC',
+  ActiveSubstancesAsc = 'ACTIVE_SUBSTANCES_ASC',
+  ActiveSubstancesDesc = 'ACTIVE_SUBSTANCES_DESC',
   PrimaryContainerAsc = 'PRIMARY_CONTAINER_ASC',
   PrimaryContainerDesc = 'PRIMARY_CONTAINER_DESC',
-  ShelfLifeOpenedAsc = 'SHELF_LIFE_OPENED_ASC',
-  ShelfLifeOpenedDesc = 'SHELF_LIFE_OPENED_DESC',
-  ManufacturersListAsc = 'MANUFACTURERS_LIST_ASC',
-  ManufacturersListDesc = 'MANUFACTURERS_LIST_DESC',
-  ShelfLifeProposedAsc = 'SHELF_LIFE_PROPOSED_ASC',
-  ShelfLifeProposedDesc = 'SHELF_LIFE_PROPOSED_DESC',
-  AdministrationRouteAsc = 'ADMINISTRATION_ROUTE_ASC',
-  AdministrationRouteDesc = 'ADMINISTRATION_ROUTE_DESC',
-  IsLocallyManufacturedAsc = 'IS_LOCALLY_MANUFACTURED_ASC',
-  IsLocallyManufacturedDesc = 'IS_LOCALLY_MANUFACTURED_DESC',
-  ShelfLifeReconstructedAsc = 'SHELF_LIFE_RECONSTRUCTED_ASC',
-  ShelfLifeReconstructedDesc = 'SHELF_LIFE_RECONSTRUCTED_DESC',
-  StorageConditionsOpenedAsc = 'STORAGE_CONDITIONS_OPENED_ASC',
-  StorageConditionsOpenedDesc = 'STORAGE_CONDITIONS_OPENED_DESC',
-  StorageConditionsProposedAsc = 'STORAGE_CONDITIONS_PROPOSED_ASC',
-  StorageConditionsProposedDesc = 'STORAGE_CONDITIONS_PROPOSED_DESC',
-  GenericNamesFilterDataAsc = 'GENERIC_NAMES_FILTER_DATA_ASC',
-  GenericNamesFilterDataDesc = 'GENERIC_NAMES_FILTER_DATA_DESC',
-  ManufacturersListFilterDataAsc = 'MANUFACTURERS_LIST_FILTER_DATA_ASC',
-  ManufacturersListFilterDataDesc = 'MANUFACTURERS_LIST_FILTER_DATA_DESC',
+  AdministrationUnitAsc = 'ADMINISTRATION_UNIT_ASC',
+  AdministrationUnitDesc = 'ADMINISTRATION_UNIT_DESC',
+  StorageTemperatureAsc = 'STORAGE_TEMPERATURE_ASC',
+  StorageTemperatureDesc = 'STORAGE_TEMPERATURE_DESC',
+  ProposedIndicationsAsc = 'PROPOSED_INDICATIONS_ASC',
+  ProposedIndicationsDesc = 'PROPOSED_INDICATIONS_DESC',
+  ComponentFormulationAsc = 'COMPONENT_FORMULATION_ASC',
+  ComponentFormulationDesc = 'COMPONENT_FORMULATION_DESC',
+  PackagingDescriptionAsc = 'PACKAGING_DESCRIPTION_ASC',
+  PackagingDescriptionDesc = 'PACKAGING_DESCRIPTION_DESC',
+  DosageFormDescriptionAsc = 'DOSAGE_FORM_DESCRIPTION_ASC',
+  DosageFormDescriptionDesc = 'DOSAGE_FORM_DESCRIPTION_DESC',
+  RouteOfAdministrationAsc = 'ROUTE_OF_ADMINISTRATION_ASC',
+  RouteOfAdministrationDesc = 'ROUTE_OF_ADMINISTRATION_DESC',
+  FinishedProductManufacturersAsc = 'FINISHED_PRODUCT_MANUFACTURERS_ASC',
+  FinishedProductManufacturersDesc = 'FINISHED_PRODUCT_MANUFACTURERS_DESC',
+  NationalMedicalClassificationAsc = 'NATIONAL_MEDICAL_CLASSIFICATION_ASC',
+  NationalMedicalClassificationDesc = 'NATIONAL_MEDICAL_CLASSIFICATION_DESC',
+  ActiveIngredientsManufacturersAsc = 'ACTIVE_INGREDIENTS_MANUFACTURERS_ASC',
+  ActiveIngredientsManufacturersDesc = 'ACTIVE_INGREDIENTS_MANUFACTURERS_DESC',
+  CompanyIdAsc = 'COMPANY_ID_ASC',
+  CompanyIdDesc = 'COMPANY_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -12912,68 +14068,134 @@ export enum DataTableProductsOrderBy {
 export type DataTableProductCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `origin` field. */
-  origin?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `isActive` field. */
-  isActive?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `expiryDate` field. */
   expiryDate?: Maybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `registration` field. */
-  registration?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `applicantName` field. */
-  applicantName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `productOrigin` field. */
+  productOrigin?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `registrationDate` field. */
   registrationDate?: Maybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `responsiblePerson` field. */
-  responsiblePerson?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `registrationSerial` field. */
+  registrationSerial?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `sra` field. */
+  sra?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
   name?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `atcCode` field. */
   atcCode?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `atcClass` field. */
-  atcClass?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `companyId` field. */
-  companyId?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `dimensions` field. */
-  dimensions?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `shelfLife` field. */
+  shelfLife?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `dosageForm` field. */
   dosageForm?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `applicantId` field. */
-  applicantId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `atcCategory` field. */
+  atcCategory?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `companyName` field. */
   companyName?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `formulations` field. */
-  formulations?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `prescription` field. */
-  prescription?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `genericNames` field. */
-  genericNames?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `medicineType` field. */
-  medicineType?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `applicationType` field. */
-  applicationType?: Maybe<Scalars['String']>;
+  formulations?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `companyPhone` field. */
+  companyPhone?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `companyAddress` field. */
+  companyAddress?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `packagingSizes` field. */
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `importerAddress` field. */
+  importerAddress?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `activeSubstances` field. */
+  activeSubstances?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `primaryContainer` field. */
   primaryContainer?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `shelfLifeOpened` field. */
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `manufacturersList` field. */
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `shelfLifeProposed` field. */
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `administrationRoute` field. */
-  administrationRoute?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `isLocallyManufactured` field. */
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `shelfLifeReconstructed` field. */
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `storageConditionsOpened` field. */
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `storageConditionsProposed` field. */
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `genericNamesFilterData` field. */
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `manufacturersListFilterData` field. */
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `administrationUnit` field. */
+  administrationUnit?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `storageTemperature` field. */
+  storageTemperature?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `proposedIndications` field. */
+  proposedIndications?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `componentFormulation` field. */
+  componentFormulation?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `packagingDescription` field. */
+  packagingDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `dosageFormDescription` field. */
+  dosageFormDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `finishedProductManufacturers` field. */
+  finishedProductManufacturers?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `nationalMedicalClassification` field. */
+  nationalMedicalClassification?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `activeIngredientsManufacturers` field. */
+  activeIngredientsManufacturers?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `companyId` field. */
+  companyId?: Maybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `DataTableProduct` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableProductFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `expiryDate` field. */
+  expiryDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `productOrigin` field. */
+  productOrigin?: Maybe<StringFilter>;
+  /** Filter by the object’s `registrationDate` field. */
+  registrationDate?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `registrationSerial` field. */
+  registrationSerial?: Maybe<StringFilter>;
+  /** Filter by the object’s `sra` field. */
+  sra?: Maybe<StringFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `atcCode` field. */
+  atcCode?: Maybe<StringFilter>;
+  /** Filter by the object’s `shelfLife` field. */
+  shelfLife?: Maybe<StringFilter>;
+  /** Filter by the object’s `dosageForm` field. */
+  dosageForm?: Maybe<StringFilter>;
+  /** Filter by the object’s `atcCategory` field. */
+  atcCategory?: Maybe<StringFilter>;
+  /** Filter by the object’s `companyName` field. */
+  companyName?: Maybe<StringFilter>;
+  /** Filter by the object’s `formulations` field. */
+  formulations?: Maybe<StringFilter>;
+  /** Filter by the object’s `companyPhone` field. */
+  companyPhone?: Maybe<StringFilter>;
+  /** Filter by the object’s `companyAddress` field. */
+  companyAddress?: Maybe<StringFilter>;
+  /** Filter by the object’s `packagingSizes` field. */
+  packagingSizes?: Maybe<JsonFilter>;
+  /** Filter by the object’s `importerAddress` field. */
+  importerAddress?: Maybe<StringFilter>;
+  /** Filter by the object’s `activeSubstances` field. */
+  activeSubstances?: Maybe<JsonFilter>;
+  /** Filter by the object’s `primaryContainer` field. */
+  primaryContainer?: Maybe<StringFilter>;
+  /** Filter by the object’s `administrationUnit` field. */
+  administrationUnit?: Maybe<StringFilter>;
+  /** Filter by the object’s `storageTemperature` field. */
+  storageTemperature?: Maybe<StringFilter>;
+  /** Filter by the object’s `proposedIndications` field. */
+  proposedIndications?: Maybe<StringFilter>;
+  /** Filter by the object’s `componentFormulation` field. */
+  componentFormulation?: Maybe<StringFilter>;
+  /** Filter by the object’s `packagingDescription` field. */
+  packagingDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `dosageFormDescription` field. */
+  dosageFormDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<StringFilter>;
+  /** Filter by the object’s `finishedProductManufacturers` field. */
+  finishedProductManufacturers?: Maybe<StringFilter>;
+  /** Filter by the object’s `nationalMedicalClassification` field. */
+  nationalMedicalClassification?: Maybe<StringFilter>;
+  /** Filter by the object’s `activeIngredientsManufacturers` field. */
+  activeIngredientsManufacturers?: Maybe<StringFilter>;
+  /** Filter by the object’s `companyId` field. */
+  companyId?: Maybe<IntFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableProductFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableProductFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableProductFilter>;
 };
 
 /** A connection to a list of `DataTableProduct` values. */
@@ -12989,6 +14211,42 @@ export type DataTableProductsConnection = {
   totalCount: Scalars['Int'];
 };
 
+export type DataTableProduct = Node & {
+  __typename?: 'DataTableProduct';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  productOrigin?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  sra?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  atcCode?: Maybe<Scalars['String']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  atcCategory?: Maybe<Scalars['String']>;
+  companyName?: Maybe<Scalars['String']>;
+  formulations?: Maybe<Scalars['String']>;
+  companyPhone?: Maybe<Scalars['String']>;
+  companyAddress?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  importerAddress?: Maybe<Scalars['String']>;
+  activeSubstances?: Maybe<Scalars['JSON']>;
+  primaryContainer?: Maybe<Scalars['String']>;
+  administrationUnit?: Maybe<Scalars['String']>;
+  storageTemperature?: Maybe<Scalars['String']>;
+  proposedIndications?: Maybe<Scalars['String']>;
+  componentFormulation?: Maybe<Scalars['String']>;
+  packagingDescription?: Maybe<Scalars['String']>;
+  dosageFormDescription?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  finishedProductManufacturers?: Maybe<Scalars['String']>;
+  nationalMedicalClassification?: Maybe<Scalars['String']>;
+  activeIngredientsManufacturers?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+};
+
 /** A `DataTableProduct` edge in the connection. */
 export type DataTableProductsEdge = {
   __typename?: 'DataTableProductsEdge';
@@ -12998,116 +14256,243 @@ export type DataTableProductsEdge = {
   node?: Maybe<DataTableProduct>;
 };
 
-/** Methods to use when ordering `DataTableProvince`. */
-export enum DataTableProvincesOrderBy {
+/** Methods to use when ordering `DataTableProvisionalProduct`. */
+export enum DataTableProvisionalProductsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  AreaAsc = 'AREA_ASC',
-  AreaDesc = 'AREA_DESC',
-  NomeAsc = 'NOME_ASC',
-  NomeDesc = 'NOME_DESC',
-  CodigoAsc = 'CODIGO_ASC',
-  CodigoDesc = 'CODIGO_DESC',
-  CapitalAsc = 'CAPITAL_ASC',
-  CapitalDesc = 'CAPITAL_DESC',
-  ComunasAsc = 'COMUNAS_ASC',
-  ComunasDesc = 'COMUNAS_DESC',
-  PopulacaoAsc = 'POPULACAO_ASC',
-  PopulacaoDesc = 'POPULACAO_DESC',
-  MunicipiosAsc = 'MUNICIPIOS_ASC',
-  MunicipiosDesc = 'MUNICIPIOS_DESC',
-  NameUppercaseAsc = 'NAME_UPPERCASE_ASC',
-  NameUppercaseDesc = 'NAME_UPPERCASE_DESC',
+  FullNameAsc = 'FULL_NAME_ASC',
+  FullNameDesc = 'FULL_NAME_DESC',
+  IsActiveAsc = 'IS_ACTIVE_ASC',
+  IsActiveDesc = 'IS_ACTIVE_DESC',
+  ProductIdAsc = 'PRODUCT_ID_ASC',
+  ProductIdDesc = 'PRODUCT_ID_DESC',
+  DosageFormAsc = 'DOSAGE_FORM_ASC',
+  DosageFormDesc = 'DOSAGE_FORM_DESC',
+  OriginalIdAsc = 'ORIGINAL_ID_ASC',
+  OriginalIdDesc = 'ORIGINAL_ID_DESC',
+  ExpiryDateAsc = 'EXPIRY_DATE_ASC',
+  ExpiryDateDesc = 'EXPIRY_DATE_DESC',
+  SponsorNameAsc = 'SPONSOR_NAME_ASC',
+  SponsorNameDesc = 'SPONSOR_NAME_DESC',
+  RegisteredInAsc = 'REGISTERED_IN_ASC',
+  RegisteredInDesc = 'REGISTERED_IN_DESC',
+  RegistrationDateAsc = 'REGISTRATION_DATE_ASC',
+  RegistrationDateDesc = 'REGISTRATION_DATE_DESC',
+  RegistrationSerialAsc = 'REGISTRATION_SERIAL_ASC',
+  RegistrationSerialDesc = 'REGISTRATION_SERIAL_DESC',
+  RouteOfAdministrationAsc = 'ROUTE_OF_ADMINISTRATION_ASC',
+  RouteOfAdministrationDesc = 'ROUTE_OF_ADMINISTRATION_DESC',
+  TradeNameAsc = 'TRADE_NAME_ASC',
+  TradeNameDesc = 'TRADE_NAME_DESC',
+  CompanyIdAsc = 'COMPANY_ID_ASC',
+  CompanyIdDesc = 'COMPANY_ID_DESC',
+  ShelfLifeAsc = 'SHELF_LIFE_ASC',
+  ShelfLifeDesc = 'SHELF_LIFE_DESC',
+  ApplicantIdAsc = 'APPLICANT_ID_ASC',
+  ApplicantIdDesc = 'APPLICANT_ID_DESC',
+  CompanyNameAsc = 'COMPANY_NAME_ASC',
+  CompanyNameDesc = 'COMPANY_NAME_DESC',
+  PackagingSizesAsc = 'PACKAGING_SIZES_ASC',
+  PackagingSizesDesc = 'PACKAGING_SIZES_DESC',
+  StorageConditionsAsc = 'STORAGE_CONDITIONS_ASC',
+  StorageConditionsDesc = 'STORAGE_CONDITIONS_DESC',
+  ActiveIngredientsAsc = 'ACTIVE_INGREDIENTS_ASC',
+  ActiveIngredientsDesc = 'ACTIVE_INGREDIENTS_DESC',
+  MedicalProductClassificationAsc = 'MEDICAL_PRODUCT_CLASSIFICATION_ASC',
+  MedicalProductClassificationDesc = 'MEDICAL_PRODUCT_CLASSIFICATION_DESC',
+  ManufacturersAsc = 'MANUFACTURERS_ASC',
+  ManufacturersDesc = 'MANUFACTURERS_DESC',
+  AtcCodeAsc = 'ATC_CODE_ASC',
+  AtcCodeDesc = 'ATC_CODE_DESC',
+  PharmacopeiaAsc = 'PHARMACOPEIA_ASC',
+  PharmacopeiaDesc = 'PHARMACOPEIA_DESC',
+  GmpCertificateAsc = 'GMP_CERTIFICATE_ASC',
+  GmpCertificateDesc = 'GMP_CERTIFICATE_DESC',
+  ProdRegCertificateAsc = 'PROD_REG_CERTIFICATE_ASC',
+  ProdRegCertificateDesc = 'PROD_REG_CERTIFICATE_DESC',
+  PrequalifiedAsc = 'PREQUALIFIED_ASC',
+  PrequalifiedDesc = 'PREQUALIFIED_DESC',
+  ManufacturerPrequalifiedAsc = 'MANUFACTURER_PREQUALIFIED_ASC',
+  ManufacturerPrequalifiedDesc = 'MANUFACTURER_PREQUALIFIED_DESC',
+  LoaSourceAsc = 'LOA_SOURCE_ASC',
+  LoaSourceDesc = 'LOA_SOURCE_DESC',
+  LetterOfAuthorisationAsc = 'LETTER_OF_AUTHORISATION_ASC',
+  LetterOfAuthorisationDesc = 'LETTER_OF_AUTHORISATION_DESC',
+  PackagingSizesFormAsc = 'PACKAGING_SIZES_FORM_ASC',
+  PackagingSizesFormDesc = 'PACKAGING_SIZES_FORM_DESC',
+  PackagingSizesFilterDataAsc = 'PACKAGING_SIZES_FILTER_DATA_ASC',
+  PackagingSizesFilterDataDesc = 'PACKAGING_SIZES_FILTER_DATA_DESC',
+  ManufacturersFilterDataAsc = 'MANUFACTURERS_FILTER_DATA_ASC',
+  ManufacturersFilterDataDesc = 'MANUFACTURERS_FILTER_DATA_DESC',
+  ActiveIngredientsFilterDataAsc = 'ACTIVE_INGREDIENTS_FILTER_DATA_ASC',
+  ActiveIngredientsFilterDataDesc = 'ACTIVE_INGREDIENTS_FILTER_DATA_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
-/** A condition to be used against `DataTableProvince` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type DataTableProvinceCondition = {
+/** A condition to be used against `DataTableProvisionalProduct` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableProvisionalProductCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `area` field. */
-  area?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `nome` field. */
-  nome?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `codigo` field. */
-  codigo?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `capital` field. */
-  capital?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `comunas` field. */
-  comunas?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `populacao` field. */
-  populacao?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `municipios` field. */
-  municipios?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `nameUppercase` field. */
-  nameUppercase?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `fullName` field. */
+  fullName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `isActive` field. */
+  isActive?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `productId` field. */
+  productId?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `dosageForm` field. */
+  dosageForm?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `originalId` field. */
+  originalId?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `expiryDate` field. */
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `sponsorName` field. */
+  sponsorName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `registeredIn` field. */
+  registeredIn?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `registrationDate` field. */
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `registrationSerial` field. */
+  registrationSerial?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `routeOfAdministration` field. */
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `tradeName` field. */
+  tradeName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `companyId` field. */
+  companyId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `shelfLife` field. */
+  shelfLife?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `applicantId` field. */
+  applicantId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `companyName` field. */
+  companyName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `packagingSizes` field. */
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `storageConditions` field. */
+  storageConditions?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `activeIngredients` field. */
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `medicalProductClassification` field. */
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `manufacturers` field. */
+  manufacturers?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `atcCode` field. */
+  atcCode?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `pharmacopeia` field. */
+  pharmacopeia?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `gmpCertificate` field. */
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `prodRegCertificate` field. */
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `prequalified` field. */
+  prequalified?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `manufacturerPrequalified` field. */
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `loaSource` field. */
+  loaSource?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `letterOfAuthorisation` field. */
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `packagingSizesForm` field. */
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `packagingSizesFilterData` field. */
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `manufacturersFilterData` field. */
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `activeIngredientsFilterData` field. */
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
 };
 
-/** A filter to be used against `DataTableProvince` object types. All fields are combined with a logical ‘and.’ */
-export type DataTableProvinceFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `area` field. */
-  area?: Maybe<StringFilter>;
-  /** Filter by the object’s `nome` field. */
-  nome?: Maybe<StringFilter>;
-  /** Filter by the object’s `codigo` field. */
-  codigo?: Maybe<StringFilter>;
-  /** Filter by the object’s `capital` field. */
-  capital?: Maybe<StringFilter>;
-  /** Filter by the object’s `comunas` field. */
-  comunas?: Maybe<StringFilter>;
-  /** Filter by the object’s `populacao` field. */
-  populacao?: Maybe<StringFilter>;
-  /** Filter by the object’s `municipios` field. */
-  municipios?: Maybe<StringFilter>;
-  /** Filter by the object’s `nameUppercase` field. */
-  nameUppercase?: Maybe<StringFilter>;
-  /** Checks for all expressions in this list. */
-  and?: Maybe<Array<DataTableProvinceFilter>>;
-  /** Checks for any expressions in this list. */
-  or?: Maybe<Array<DataTableProvinceFilter>>;
-  /** Negates the expression. */
-  not?: Maybe<DataTableProvinceFilter>;
-};
-
-/** A connection to a list of `DataTableProvince` values. */
-export type DataTableProvincesConnection = {
-  __typename?: 'DataTableProvincesConnection';
-  /** A list of `DataTableProvince` objects. */
-  nodes: Array<Maybe<DataTableProvince>>;
-  /** A list of edges which contains the `DataTableProvince` and cursor to aid in pagination. */
-  edges: Array<DataTableProvincesEdge>;
+/** A connection to a list of `DataTableProvisionalProduct` values. */
+export type DataTableProvisionalProductsConnection = {
+  __typename?: 'DataTableProvisionalProductsConnection';
+  /** A list of `DataTableProvisionalProduct` objects. */
+  nodes: Array<Maybe<DataTableProvisionalProduct>>;
+  /** A list of edges which contains the `DataTableProvisionalProduct` and cursor to aid in pagination. */
+  edges: Array<DataTableProvisionalProductsEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
-  /** The count of *all* `DataTableProvince` you could get from the connection. */
+  /** The count of *all* `DataTableProvisionalProduct` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
 
-export type DataTableProvince = Node & {
-  __typename?: 'DataTableProvince';
+/** A `DataTableProvisionalProduct` edge in the connection. */
+export type DataTableProvisionalProductsEdge = {
+  __typename?: 'DataTableProvisionalProductsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `DataTableProvisionalProduct` at the end of the edge. */
+  node?: Maybe<DataTableProvisionalProduct>;
+};
+
+/** Methods to use when ordering `DataTableScheduledChemical`. */
+export enum DataTableScheduledChemicalsOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  ChemicalAsc = 'CHEMICAL_ASC',
+  ChemicalDesc = 'CHEMICAL_DESC',
+  ScheduleAsc = 'SCHEDULE_ASC',
+  ScheduleDesc = 'SCHEDULE_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `DataTableScheduledChemical` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type DataTableScheduledChemicalCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `chemical` field. */
+  chemical?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `schedule` field. */
+  schedule?: Maybe<Scalars['String']>;
+};
+
+/** A filter to be used against `DataTableScheduledChemical` object types. All fields are combined with a logical ‘and.’ */
+export type DataTableScheduledChemicalFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `chemical` field. */
+  chemical?: Maybe<StringFilter>;
+  /** Filter by the object’s `schedule` field. */
+  schedule?: Maybe<StringFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<DataTableScheduledChemicalFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<DataTableScheduledChemicalFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<DataTableScheduledChemicalFilter>;
+};
+
+/** A connection to a list of `DataTableScheduledChemical` values. */
+export type DataTableScheduledChemicalsConnection = {
+  __typename?: 'DataTableScheduledChemicalsConnection';
+  /** A list of `DataTableScheduledChemical` objects. */
+  nodes: Array<Maybe<DataTableScheduledChemical>>;
+  /** A list of edges which contains the `DataTableScheduledChemical` and cursor to aid in pagination. */
+  edges: Array<DataTableScheduledChemicalsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `DataTableScheduledChemical` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type DataTableScheduledChemical = Node & {
+  __typename?: 'DataTableScheduledChemical';
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  area?: Maybe<Scalars['String']>;
-  nome?: Maybe<Scalars['String']>;
-  codigo?: Maybe<Scalars['String']>;
-  capital?: Maybe<Scalars['String']>;
-  comunas?: Maybe<Scalars['String']>;
-  populacao?: Maybe<Scalars['String']>;
-  municipios?: Maybe<Scalars['String']>;
-  nameUppercase?: Maybe<Scalars['String']>;
+  chemical?: Maybe<Scalars['String']>;
+  schedule?: Maybe<Scalars['String']>;
 };
 
-/** A `DataTableProvince` edge in the connection. */
-export type DataTableProvincesEdge = {
-  __typename?: 'DataTableProvincesEdge';
+/** A `DataTableScheduledChemical` edge in the connection. */
+export type DataTableScheduledChemicalsEdge = {
+  __typename?: 'DataTableScheduledChemicalsEdge';
   /** A cursor for use in pagination. */
   cursor?: Maybe<Scalars['Cursor']>;
-  /** The `DataTableProvince` at the end of the edge. */
-  node?: Maybe<DataTableProvince>;
+  /** The `DataTableScheduledChemical` at the end of the edge. */
+  node?: Maybe<DataTableScheduledChemical>;
 };
 
 /** Methods to use when ordering `DataTableStorageCondition`. */
@@ -13115,10 +14500,12 @@ export enum DataTableStorageConditionsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
-  PortugueseNameAsc = 'PORTUGUESE_NAME_ASC',
-  PortugueseNameDesc = 'PORTUGUESE_NAME_DESC',
+  CodeAsc = 'CODE_ASC',
+  CodeDesc = 'CODE_DESC',
+  LongDescriptionAsc = 'LONG_DESCRIPTION_ASC',
+  LongDescriptionDesc = 'LONG_DESCRIPTION_DESC',
+  ShortDescriptionAsc = 'SHORT_DESCRIPTION_ASC',
+  ShortDescriptionDesc = 'SHORT_DESCRIPTION_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -13127,20 +14514,24 @@ export enum DataTableStorageConditionsOrderBy {
 export type DataTableStorageConditionCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `portugueseName` field. */
-  portugueseName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `code` field. */
+  code?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `longDescription` field. */
+  longDescription?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `shortDescription` field. */
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A filter to be used against `DataTableStorageCondition` object types. All fields are combined with a logical ‘and.’ */
 export type DataTableStorageConditionFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
-  /** Filter by the object’s `portugueseName` field. */
-  portugueseName?: Maybe<StringFilter>;
+  /** Filter by the object’s `code` field. */
+  code?: Maybe<StringFilter>;
+  /** Filter by the object’s `longDescription` field. */
+  longDescription?: Maybe<StringFilter>;
+  /** Filter by the object’s `shortDescription` field. */
+  shortDescription?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableStorageConditionFilter>>;
   /** Checks for any expressions in this list. */
@@ -13167,8 +14558,9 @@ export type DataTableStorageCondition = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** A `DataTableStorageCondition` edge in the connection. */
@@ -13821,6 +15213,88 @@ export type FiltersEdge = {
   node?: Maybe<Filter>;
 };
 
+/** Methods to use when ordering `GrafanaDashboardImage`. */
+export enum GrafanaDashboardImagesOrderBy {
+  Natural = 'NATURAL',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  DescriptionAsc = 'DESCRIPTION_ASC',
+  DescriptionDesc = 'DESCRIPTION_DESC',
+  DataAsc = 'DATA_ASC',
+  DataDesc = 'DATA_DESC',
+  UpdatedDateAsc = 'UPDATED_DATE_ASC',
+  UpdatedDateDesc = 'UPDATED_DATE_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A condition to be used against `GrafanaDashboardImage` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type GrafanaDashboardImageCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `description` field. */
+  description?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `data` field. */
+  data?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `updatedDate` field. */
+  updatedDate?: Maybe<Scalars['Datetime']>;
+};
+
+/** A filter to be used against `GrafanaDashboardImage` object types. All fields are combined with a logical ‘and.’ */
+export type GrafanaDashboardImageFilter = {
+  /** Filter by the object’s `id` field. */
+  id?: Maybe<IntFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: Maybe<StringFilter>;
+  /** Filter by the object’s `description` field. */
+  description?: Maybe<StringFilter>;
+  /** Filter by the object’s `updatedDate` field. */
+  updatedDate?: Maybe<DatetimeFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<GrafanaDashboardImageFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<GrafanaDashboardImageFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<GrafanaDashboardImageFilter>;
+};
+
+/** A connection to a list of `GrafanaDashboardImage` values. */
+export type GrafanaDashboardImagesConnection = {
+  __typename?: 'GrafanaDashboardImagesConnection';
+  /** A list of `GrafanaDashboardImage` objects. */
+  nodes: Array<Maybe<GrafanaDashboardImage>>;
+  /** A list of edges which contains the `GrafanaDashboardImage` and cursor to aid in pagination. */
+  edges: Array<GrafanaDashboardImagesEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `GrafanaDashboardImage` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+export type GrafanaDashboardImage = Node & {
+  __typename?: 'GrafanaDashboardImage';
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['String']>;
+  updatedDate?: Maybe<Scalars['Datetime']>;
+};
+
+/** A `GrafanaDashboardImage` edge in the connection. */
+export type GrafanaDashboardImagesEdge = {
+  __typename?: 'GrafanaDashboardImagesEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `GrafanaDashboardImage` at the end of the edge. */
+  node?: Maybe<GrafanaDashboardImage>;
+};
+
 /** Methods to use when ordering `Organisation`. */
 export enum OrganisationsOrderBy {
   Natural = 'NATURAL',
@@ -13838,32 +15312,38 @@ export enum OrganisationsOrderBy {
   IsSystemOrgDesc = 'IS_SYSTEM_ORG_DESC',
   RegistrationDocumentationAsc = 'REGISTRATION_DOCUMENTATION_ASC',
   RegistrationDocumentationDesc = 'REGISTRATION_DOCUMENTATION_DESC',
-  AgentAsc = 'AGENT_ASC',
-  AgentDesc = 'AGENT_DESC',
-  ContactAsc = 'CONTACT_ASC',
-  ContactDesc = 'CONTACT_DESC',
-  AuthorisationAsc = 'AUTHORISATION_ASC',
-  AuthorisationDesc = 'AUTHORISATION_DESC',
   CountryAsc = 'COUNTRY_ASC',
   CountryDesc = 'COUNTRY_DESC',
   ProvinceAsc = 'PROVINCE_ASC',
   ProvinceDesc = 'PROVINCE_DESC',
+  ContactEmailAsc = 'CONTACT_EMAIL_ASC',
+  ContactEmailDesc = 'CONTACT_EMAIL_DESC',
+  ContactPhoneAsc = 'CONTACT_PHONE_ASC',
+  ContactPhoneDesc = 'CONTACT_PHONE_DESC',
   PostalAddressAsc = 'POSTAL_ADDRESS_ASC',
   PostalAddressDesc = 'POSTAL_ADDRESS_DESC',
-  PostalCountryAsc = 'POSTAL_COUNTRY_ASC',
-  PostalCountryDesc = 'POSTAL_COUNTRY_DESC',
-  PostalProvinceAsc = 'POSTAL_PROVINCE_ASC',
-  PostalProvinceDesc = 'POSTAL_PROVINCE_DESC',
-  IsActiveAsc = 'IS_ACTIVE_ASC',
-  IsActiveDesc = 'IS_ACTIVE_DESC',
-  RegistrationDateAsc = 'REGISTRATION_DATE_ASC',
-  RegistrationDateDesc = 'REGISTRATION_DATE_DESC',
-  AgentIdAsc = 'AGENT_ID_ASC',
-  AgentIdDesc = 'AGENT_ID_DESC',
-  TypeAsc = 'TYPE_ASC',
-  TypeDesc = 'TYPE_DESC',
-  NifNumberAsc = 'NIF_NUMBER_ASC',
-  NifNumberDesc = 'NIF_NUMBER_DESC',
+  LocalAgentNameAsc = 'LOCAL_AGENT_NAME_ASC',
+  LocalAgentNameDesc = 'LOCAL_AGENT_NAME_DESC',
+  LocalAgentEmailAsc = 'LOCAL_AGENT_EMAIL_ASC',
+  LocalAgentEmailDesc = 'LOCAL_AGENT_EMAIL_DESC',
+  LocalAgentPhoneNumberAsc = 'LOCAL_AGENT_PHONE_NUMBER_ASC',
+  LocalAgentPhoneNumberDesc = 'LOCAL_AGENT_PHONE_NUMBER_DESC',
+  LocalAgentBusinessAddressAsc = 'LOCAL_AGENT_BUSINESS_ADDRESS_ASC',
+  LocalAgentBusinessAddressDesc = 'LOCAL_AGENT_BUSINESS_ADDRESS_DESC',
+  LicenseAsc = 'LICENSE_ASC',
+  LicenseDesc = 'LICENSE_DESC',
+  BusinessCertificateAsc = 'BUSINESS_CERTIFICATE_ASC',
+  BusinessCertificateDesc = 'BUSINESS_CERTIFICATE_DESC',
+  TinLetterAsc = 'TIN_LETTER_ASC',
+  TinLetterDesc = 'TIN_LETTER_DESC',
+  SubTypeAsc = 'SUB_TYPE_ASC',
+  SubTypeDesc = 'SUB_TYPE_DESC',
+  OtherDocumentsAsc = 'OTHER_DOCUMENTS_ASC',
+  OtherDocumentsDesc = 'OTHER_DOCUMENTS_DESC',
+  IsSponsorCompanyAsc = 'IS_SPONSOR_COMPANY_ASC',
+  IsSponsorCompanyDesc = 'IS_SPONSOR_COMPANY_DESC',
+  IsChemicalImporterAsc = 'IS_CHEMICAL_IMPORTER_ASC',
+  IsChemicalImporterDesc = 'IS_CHEMICAL_IMPORTER_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -13884,32 +15364,38 @@ export type OrganisationCondition = {
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `registrationDocumentation` field. */
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `agent` field. */
-  agent?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `contact` field. */
-  contact?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `authorisation` field. */
-  authorisation?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `country` field. */
   country?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `province` field. */
   province?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `contactEmail` field. */
+  contactEmail?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `contactPhone` field. */
+  contactPhone?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `postalAddress` field. */
   postalAddress?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `postalCountry` field. */
-  postalCountry?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `postalProvince` field. */
-  postalProvince?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `isActive` field. */
-  isActive?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `registrationDate` field. */
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `agentId` field. */
-  agentId?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `type` field. */
-  type?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `nifNumber` field. */
-  nifNumber?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `localAgentName` field. */
+  localAgentName?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `localAgentEmail` field. */
+  localAgentEmail?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `localAgentPhoneNumber` field. */
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `localAgentBusinessAddress` field. */
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `license` field. */
+  license?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `businessCertificate` field. */
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `tinLetter` field. */
+  tinLetter?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `subType` field. */
+  subType?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `otherDocuments` field. */
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `isSponsorCompany` field. */
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `isChemicalImporter` field. */
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
 };
 
 /** A connection to a list of `Organisation` values. */
@@ -14862,16 +16348,6 @@ export enum UsersOrderBy {
   AddressDesc = 'ADDRESS_DESC',
   CountryAsc = 'COUNTRY_ASC',
   CountryDesc = 'COUNTRY_DESC',
-  ProvinceAsc = 'PROVINCE_ASC',
-  ProvinceDesc = 'PROVINCE_DESC',
-  RegistrationDateAsc = 'REGISTRATION_DATE_ASC',
-  RegistrationDateDesc = 'REGISTRATION_DATE_DESC',
-  NationalIdAsc = 'NATIONAL_ID_ASC',
-  NationalIdDesc = 'NATIONAL_ID_DESC',
-  ForeignIdAsc = 'FOREIGN_ID_ASC',
-  ForeignIdDesc = 'FOREIGN_ID_DESC',
-  ForeignIdTypeAsc = 'FOREIGN_ID_TYPE_ASC',
-  ForeignIdTypeDesc = 'FOREIGN_ID_TYPE_DESC',
   FullNameAsc = 'FULL_NAME_ASC',
   FullNameDesc = 'FULL_NAME_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -14900,16 +16376,6 @@ export type UserCondition = {
   address?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `country` field. */
   country?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `province` field. */
-  province?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `registrationDate` field. */
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `nationalId` field. */
-  nationalId?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `foreignId` field. */
-  foreignId?: Maybe<Scalars['JSON']>;
-  /** Checks for equality with the object’s `foreignIdType` field. */
-  foreignIdType?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `fullName` field. */
   fullName?: Maybe<Scalars['String']>;
 };
@@ -15433,6 +16899,8 @@ export type Mutation = {
   createApplicationNote?: Maybe<CreateApplicationNotePayload>;
   /** Creates a single `ApplicationResponse`. */
   createApplicationResponse?: Maybe<CreateApplicationResponsePayload>;
+  /** Creates a single `ApplicationReviewerAction`. */
+  createApplicationReviewerAction?: Maybe<CreateApplicationReviewerActionPayload>;
   /** Creates a single `ApplicationStageHistory`. */
   createApplicationStageHistory?: Maybe<CreateApplicationStageHistoryPayload>;
   /** Creates a single `ApplicationStatusHistory`. */
@@ -15443,8 +16911,6 @@ export type Mutation = {
   createDataChangelog?: Maybe<CreateDataChangelogPayload>;
   /** Creates a single `DataTable`. */
   createDataTable?: Maybe<CreateDataTablePayload>;
-  /** Creates a single `DataTableManufacturingStep`. */
-  createDataTableManufacturingStep?: Maybe<CreateDataTableManufacturingStepPayload>;
   /** Creates a single `DataTableActiveIngredient`. */
   createDataTableActiveIngredient?: Maybe<CreateDataTableActiveIngredientPayload>;
   /** Creates a single `DataTableAdministrationRoute`. */
@@ -15455,32 +16921,48 @@ export type Mutation = {
   createDataTableAnnex2?: Maybe<CreateDataTableAnnex2Payload>;
   /** Creates a single `DataTableAtcCode`. */
   createDataTableAtcCode?: Maybe<CreateDataTableAtcCodePayload>;
-  /** Creates a single `DataTableAtcTherapeuticCategory`. */
-  createDataTableAtcTherapeuticCategory?: Maybe<CreateDataTableAtcTherapeuticCategoryPayload>;
   /** Creates a single `DataTableContainer`. */
   createDataTableContainer?: Maybe<CreateDataTableContainerPayload>;
   /** Creates a single `DataTableCountry`. */
   createDataTableCountry?: Maybe<CreateDataTableCountryPayload>;
   /** Creates a single `DataTableDosageForm`. */
   createDataTableDosageForm?: Maybe<CreateDataTableDosageFormPayload>;
+  /** Creates a single `DataTableDosageFormGroup`. */
+  createDataTableDosageFormGroup?: Maybe<CreateDataTableDosageFormGroupPayload>;
   /** Creates a single `DataTableGenericIngredient`. */
   createDataTableGenericIngredient?: Maybe<CreateDataTableGenericIngredientPayload>;
-  /** Creates a single `DataTableIngredientsList`. */
-  createDataTableIngredientsList?: Maybe<CreateDataTableIngredientsListPayload>;
-  /** Creates a single `DataTableInternationalDiallingPrefix`. */
-  createDataTableInternationalDiallingPrefix?: Maybe<CreateDataTableInternationalDiallingPrefixPayload>;
   /** Creates a single `DataTableListOfSra`. */
   createDataTableListOfSra?: Maybe<CreateDataTableListOfSraPayload>;
-  /** Creates a single `DataTableManufacturingStepsSimpler`. */
-  createDataTableManufacturingStepsSimpler?: Maybe<CreateDataTableManufacturingStepsSimplerPayload>;
+  /** Creates a single `DataTableManufacturer`. */
+  createDataTableManufacturer?: Maybe<CreateDataTableManufacturerPayload>;
+  /** Creates a single `DataTableManufacturerApplicationJoin`. */
+  createDataTableManufacturerApplicationJoin?: Maybe<CreateDataTableManufacturerApplicationJoinPayload>;
+  /** Creates a single `DataTableManufacturerRepresentative`. */
+  createDataTableManufacturerRepresentative?: Maybe<CreateDataTableManufacturerRepresentativePayload>;
+  /** Creates a single `DataTableManufacturerRepresentativeApplicationJoin`. */
+  createDataTableManufacturerRepresentativeApplicationJoin?: Maybe<CreateDataTableManufacturerRepresentativeApplicationJoinPayload>;
+  /** Creates a single `DataTablePermitChemical`. */
+  createDataTablePermitChemical?: Maybe<CreateDataTablePermitChemicalPayload>;
+  /** Creates a single `DataTablePermitChemicalApplicationJoin`. */
+  createDataTablePermitChemicalApplicationJoin?: Maybe<CreateDataTablePermitChemicalApplicationJoinPayload>;
+  /** Creates a single `DataTablePreRegisteredProductsProvisional`. */
+  createDataTablePreRegisteredProductsProvisional?: Maybe<CreateDataTablePreRegisteredProductsProvisionalPayload>;
+  /** Creates a single `DataTablePrequalManufacturer`. */
+  createDataTablePrequalManufacturer?: Maybe<CreateDataTablePrequalManufacturerPayload>;
+  /** Creates a single `DataTablePrequalManufacturerApplicationJoin`. */
+  createDataTablePrequalManufacturerApplicationJoin?: Maybe<CreateDataTablePrequalManufacturerApplicationJoinPayload>;
   /** Creates a single `DataTableProcessingStep`. */
   createDataTableProcessingStep?: Maybe<CreateDataTableProcessingStepPayload>;
   /** Creates a single `DataTableProduct`. */
   createDataTableProduct?: Maybe<CreateDataTableProductPayload>;
   /** Creates a single `DataTableProductApplicationJoin`. */
   createDataTableProductApplicationJoin?: Maybe<CreateDataTableProductApplicationJoinPayload>;
-  /** Creates a single `DataTableProvince`. */
-  createDataTableProvince?: Maybe<CreateDataTableProvincePayload>;
+  /** Creates a single `DataTableProvisionalProduct`. */
+  createDataTableProvisionalProduct?: Maybe<CreateDataTableProvisionalProductPayload>;
+  /** Creates a single `DataTableProvisionalProductApplicationJoin`. */
+  createDataTableProvisionalProductApplicationJoin?: Maybe<CreateDataTableProvisionalProductApplicationJoinPayload>;
+  /** Creates a single `DataTableScheduledChemical`. */
+  createDataTableScheduledChemical?: Maybe<CreateDataTableScheduledChemicalPayload>;
   /** Creates a single `DataTableStorageCondition`. */
   createDataTableStorageCondition?: Maybe<CreateDataTableStorageConditionPayload>;
   /** Creates a single `DataTableStorageConditionsSimplified`. */
@@ -15497,6 +16979,8 @@ export type Mutation = {
   createFile?: Maybe<CreateFilePayload>;
   /** Creates a single `Filter`. */
   createFilter?: Maybe<CreateFilterPayload>;
+  /** Creates a single `GrafanaDashboardImage`. */
+  createGrafanaDashboardImage?: Maybe<CreateGrafanaDashboardImagePayload>;
   /** Creates a single `Notification`. */
   createNotification?: Maybe<CreateNotificationPayload>;
   /** Creates a single `Organisation`. */
@@ -15509,8 +16993,6 @@ export type Mutation = {
   createPermissionName?: Maybe<CreatePermissionNamePayload>;
   /** Creates a single `PermissionPolicy`. */
   createPermissionPolicy?: Maybe<CreatePermissionPolicyPayload>;
-  /** Creates a single `ProductApplicationJoin`. */
-  createProductApplicationJoin?: Maybe<CreateProductApplicationJoinPayload>;
   /** Creates a single `Review`. */
   createReview?: Maybe<CreateReviewPayload>;
   /** Creates a single `ReviewAssignment`. */
@@ -15555,8 +17037,6 @@ export type Mutation = {
   createUserApplicationJoin?: Maybe<CreateUserApplicationJoinPayload>;
   /** Creates a single `UserOrganisation`. */
   createUserOrganisation?: Maybe<CreateUserOrganisationPayload>;
-  /** Creates a single `UserOrganisationApplicationJoin`. */
-  createUserOrganisationApplicationJoin?: Maybe<CreateUserOrganisationApplicationJoinPayload>;
   /** Creates a single `Verification`. */
   createVerification?: Maybe<CreateVerificationPayload>;
   /** Updates a single `ActionPlugin` using its globally unique id and a patch. */
@@ -15589,6 +17069,12 @@ export type Mutation = {
   updateApplicationResponseByNodeId?: Maybe<UpdateApplicationResponsePayload>;
   /** Updates a single `ApplicationResponse` using a unique key and a patch. */
   updateApplicationResponse?: Maybe<UpdateApplicationResponsePayload>;
+  /** Updates a single `ApplicationReviewerAction` using its globally unique id and a patch. */
+  updateApplicationReviewerActionByNodeId?: Maybe<UpdateApplicationReviewerActionPayload>;
+  /** Updates a single `ApplicationReviewerAction` using a unique key and a patch. */
+  updateApplicationReviewerAction?: Maybe<UpdateApplicationReviewerActionPayload>;
+  /** Updates a single `ApplicationReviewerAction` using a unique key and a patch. */
+  updateApplicationReviewerActionByUserIdAndApplicationId?: Maybe<UpdateApplicationReviewerActionPayload>;
   /** Updates a single `ApplicationStageHistory` using its globally unique id and a patch. */
   updateApplicationStageHistoryByNodeId?: Maybe<UpdateApplicationStageHistoryPayload>;
   /** Updates a single `ApplicationStageHistory` using a unique key and a patch. */
@@ -15613,10 +17099,6 @@ export type Mutation = {
   updateDataTable?: Maybe<UpdateDataTablePayload>;
   /** Updates a single `DataTable` using a unique key and a patch. */
   updateDataTableByTableName?: Maybe<UpdateDataTablePayload>;
-  /** Updates a single `DataTableManufacturingStep` using its globally unique id and a patch. */
-  updateDataTableManufacturingStepByNodeId?: Maybe<UpdateDataTableManufacturingStepPayload>;
-  /** Updates a single `DataTableManufacturingStep` using a unique key and a patch. */
-  updateDataTableManufacturingStep?: Maybe<UpdateDataTableManufacturingStepPayload>;
   /** Updates a single `DataTableActiveIngredient` using its globally unique id and a patch. */
   updateDataTableActiveIngredientByNodeId?: Maybe<UpdateDataTableActiveIngredientPayload>;
   /** Updates a single `DataTableActiveIngredient` using a unique key and a patch. */
@@ -15637,10 +17119,6 @@ export type Mutation = {
   updateDataTableAtcCodeByNodeId?: Maybe<UpdateDataTableAtcCodePayload>;
   /** Updates a single `DataTableAtcCode` using a unique key and a patch. */
   updateDataTableAtcCode?: Maybe<UpdateDataTableAtcCodePayload>;
-  /** Updates a single `DataTableAtcTherapeuticCategory` using its globally unique id and a patch. */
-  updateDataTableAtcTherapeuticCategoryByNodeId?: Maybe<UpdateDataTableAtcTherapeuticCategoryPayload>;
-  /** Updates a single `DataTableAtcTherapeuticCategory` using a unique key and a patch. */
-  updateDataTableAtcTherapeuticCategory?: Maybe<UpdateDataTableAtcTherapeuticCategoryPayload>;
   /** Updates a single `DataTableContainer` using its globally unique id and a patch. */
   updateDataTableContainerByNodeId?: Maybe<UpdateDataTableContainerPayload>;
   /** Updates a single `DataTableContainer` using a unique key and a patch. */
@@ -15653,26 +17131,54 @@ export type Mutation = {
   updateDataTableDosageFormByNodeId?: Maybe<UpdateDataTableDosageFormPayload>;
   /** Updates a single `DataTableDosageForm` using a unique key and a patch. */
   updateDataTableDosageForm?: Maybe<UpdateDataTableDosageFormPayload>;
+  /** Updates a single `DataTableDosageFormGroup` using its globally unique id and a patch. */
+  updateDataTableDosageFormGroupByNodeId?: Maybe<UpdateDataTableDosageFormGroupPayload>;
+  /** Updates a single `DataTableDosageFormGroup` using a unique key and a patch. */
+  updateDataTableDosageFormGroup?: Maybe<UpdateDataTableDosageFormGroupPayload>;
   /** Updates a single `DataTableGenericIngredient` using its globally unique id and a patch. */
   updateDataTableGenericIngredientByNodeId?: Maybe<UpdateDataTableGenericIngredientPayload>;
   /** Updates a single `DataTableGenericIngredient` using a unique key and a patch. */
   updateDataTableGenericIngredient?: Maybe<UpdateDataTableGenericIngredientPayload>;
-  /** Updates a single `DataTableIngredientsList` using its globally unique id and a patch. */
-  updateDataTableIngredientsListByNodeId?: Maybe<UpdateDataTableIngredientsListPayload>;
-  /** Updates a single `DataTableIngredientsList` using a unique key and a patch. */
-  updateDataTableIngredientsList?: Maybe<UpdateDataTableIngredientsListPayload>;
-  /** Updates a single `DataTableInternationalDiallingPrefix` using its globally unique id and a patch. */
-  updateDataTableInternationalDiallingPrefixByNodeId?: Maybe<UpdateDataTableInternationalDiallingPrefixPayload>;
-  /** Updates a single `DataTableInternationalDiallingPrefix` using a unique key and a patch. */
-  updateDataTableInternationalDiallingPrefix?: Maybe<UpdateDataTableInternationalDiallingPrefixPayload>;
   /** Updates a single `DataTableListOfSra` using its globally unique id and a patch. */
   updateDataTableListOfSraByNodeId?: Maybe<UpdateDataTableListOfSraPayload>;
   /** Updates a single `DataTableListOfSra` using a unique key and a patch. */
   updateDataTableListOfSra?: Maybe<UpdateDataTableListOfSraPayload>;
-  /** Updates a single `DataTableManufacturingStepsSimpler` using its globally unique id and a patch. */
-  updateDataTableManufacturingStepsSimplerByNodeId?: Maybe<UpdateDataTableManufacturingStepsSimplerPayload>;
-  /** Updates a single `DataTableManufacturingStepsSimpler` using a unique key and a patch. */
-  updateDataTableManufacturingStepsSimpler?: Maybe<UpdateDataTableManufacturingStepsSimplerPayload>;
+  /** Updates a single `DataTableManufacturer` using its globally unique id and a patch. */
+  updateDataTableManufacturerByNodeId?: Maybe<UpdateDataTableManufacturerPayload>;
+  /** Updates a single `DataTableManufacturer` using a unique key and a patch. */
+  updateDataTableManufacturer?: Maybe<UpdateDataTableManufacturerPayload>;
+  /** Updates a single `DataTableManufacturerApplicationJoin` using its globally unique id and a patch. */
+  updateDataTableManufacturerApplicationJoinByNodeId?: Maybe<UpdateDataTableManufacturerApplicationJoinPayload>;
+  /** Updates a single `DataTableManufacturerApplicationJoin` using a unique key and a patch. */
+  updateDataTableManufacturerApplicationJoin?: Maybe<UpdateDataTableManufacturerApplicationJoinPayload>;
+  /** Updates a single `DataTableManufacturerRepresentative` using its globally unique id and a patch. */
+  updateDataTableManufacturerRepresentativeByNodeId?: Maybe<UpdateDataTableManufacturerRepresentativePayload>;
+  /** Updates a single `DataTableManufacturerRepresentative` using a unique key and a patch. */
+  updateDataTableManufacturerRepresentative?: Maybe<UpdateDataTableManufacturerRepresentativePayload>;
+  /** Updates a single `DataTableManufacturerRepresentativeApplicationJoin` using its globally unique id and a patch. */
+  updateDataTableManufacturerRepresentativeApplicationJoinByNodeId?: Maybe<UpdateDataTableManufacturerRepresentativeApplicationJoinPayload>;
+  /** Updates a single `DataTableManufacturerRepresentativeApplicationJoin` using a unique key and a patch. */
+  updateDataTableManufacturerRepresentativeApplicationJoin?: Maybe<UpdateDataTableManufacturerRepresentativeApplicationJoinPayload>;
+  /** Updates a single `DataTablePermitChemical` using its globally unique id and a patch. */
+  updateDataTablePermitChemicalByNodeId?: Maybe<UpdateDataTablePermitChemicalPayload>;
+  /** Updates a single `DataTablePermitChemical` using a unique key and a patch. */
+  updateDataTablePermitChemical?: Maybe<UpdateDataTablePermitChemicalPayload>;
+  /** Updates a single `DataTablePermitChemicalApplicationJoin` using its globally unique id and a patch. */
+  updateDataTablePermitChemicalApplicationJoinByNodeId?: Maybe<UpdateDataTablePermitChemicalApplicationJoinPayload>;
+  /** Updates a single `DataTablePermitChemicalApplicationJoin` using a unique key and a patch. */
+  updateDataTablePermitChemicalApplicationJoin?: Maybe<UpdateDataTablePermitChemicalApplicationJoinPayload>;
+  /** Updates a single `DataTablePreRegisteredProductsProvisional` using its globally unique id and a patch. */
+  updateDataTablePreRegisteredProductsProvisionalByNodeId?: Maybe<UpdateDataTablePreRegisteredProductsProvisionalPayload>;
+  /** Updates a single `DataTablePreRegisteredProductsProvisional` using a unique key and a patch. */
+  updateDataTablePreRegisteredProductsProvisional?: Maybe<UpdateDataTablePreRegisteredProductsProvisionalPayload>;
+  /** Updates a single `DataTablePrequalManufacturer` using its globally unique id and a patch. */
+  updateDataTablePrequalManufacturerByNodeId?: Maybe<UpdateDataTablePrequalManufacturerPayload>;
+  /** Updates a single `DataTablePrequalManufacturer` using a unique key and a patch. */
+  updateDataTablePrequalManufacturer?: Maybe<UpdateDataTablePrequalManufacturerPayload>;
+  /** Updates a single `DataTablePrequalManufacturerApplicationJoin` using its globally unique id and a patch. */
+  updateDataTablePrequalManufacturerApplicationJoinByNodeId?: Maybe<UpdateDataTablePrequalManufacturerApplicationJoinPayload>;
+  /** Updates a single `DataTablePrequalManufacturerApplicationJoin` using a unique key and a patch. */
+  updateDataTablePrequalManufacturerApplicationJoin?: Maybe<UpdateDataTablePrequalManufacturerApplicationJoinPayload>;
   /** Updates a single `DataTableProcessingStep` using its globally unique id and a patch. */
   updateDataTableProcessingStepByNodeId?: Maybe<UpdateDataTableProcessingStepPayload>;
   /** Updates a single `DataTableProcessingStep` using a unique key and a patch. */
@@ -15685,10 +17191,18 @@ export type Mutation = {
   updateDataTableProductApplicationJoinByNodeId?: Maybe<UpdateDataTableProductApplicationJoinPayload>;
   /** Updates a single `DataTableProductApplicationJoin` using a unique key and a patch. */
   updateDataTableProductApplicationJoin?: Maybe<UpdateDataTableProductApplicationJoinPayload>;
-  /** Updates a single `DataTableProvince` using its globally unique id and a patch. */
-  updateDataTableProvinceByNodeId?: Maybe<UpdateDataTableProvincePayload>;
-  /** Updates a single `DataTableProvince` using a unique key and a patch. */
-  updateDataTableProvince?: Maybe<UpdateDataTableProvincePayload>;
+  /** Updates a single `DataTableProvisionalProduct` using its globally unique id and a patch. */
+  updateDataTableProvisionalProductByNodeId?: Maybe<UpdateDataTableProvisionalProductPayload>;
+  /** Updates a single `DataTableProvisionalProduct` using a unique key and a patch. */
+  updateDataTableProvisionalProduct?: Maybe<UpdateDataTableProvisionalProductPayload>;
+  /** Updates a single `DataTableProvisionalProductApplicationJoin` using its globally unique id and a patch. */
+  updateDataTableProvisionalProductApplicationJoinByNodeId?: Maybe<UpdateDataTableProvisionalProductApplicationJoinPayload>;
+  /** Updates a single `DataTableProvisionalProductApplicationJoin` using a unique key and a patch. */
+  updateDataTableProvisionalProductApplicationJoin?: Maybe<UpdateDataTableProvisionalProductApplicationJoinPayload>;
+  /** Updates a single `DataTableScheduledChemical` using its globally unique id and a patch. */
+  updateDataTableScheduledChemicalByNodeId?: Maybe<UpdateDataTableScheduledChemicalPayload>;
+  /** Updates a single `DataTableScheduledChemical` using a unique key and a patch. */
+  updateDataTableScheduledChemical?: Maybe<UpdateDataTableScheduledChemicalPayload>;
   /** Updates a single `DataTableStorageCondition` using its globally unique id and a patch. */
   updateDataTableStorageConditionByNodeId?: Maybe<UpdateDataTableStorageConditionPayload>;
   /** Updates a single `DataTableStorageCondition` using a unique key and a patch. */
@@ -15729,6 +17243,10 @@ export type Mutation = {
   updateFilter?: Maybe<UpdateFilterPayload>;
   /** Updates a single `Filter` using a unique key and a patch. */
   updateFilterByCode?: Maybe<UpdateFilterPayload>;
+  /** Updates a single `GrafanaDashboardImage` using its globally unique id and a patch. */
+  updateGrafanaDashboardImageByNodeId?: Maybe<UpdateGrafanaDashboardImagePayload>;
+  /** Updates a single `GrafanaDashboardImage` using a unique key and a patch. */
+  updateGrafanaDashboardImage?: Maybe<UpdateGrafanaDashboardImagePayload>;
   /** Updates a single `Notification` using its globally unique id and a patch. */
   updateNotificationByNodeId?: Maybe<UpdateNotificationPayload>;
   /** Updates a single `Notification` using a unique key and a patch. */
@@ -15761,10 +17279,6 @@ export type Mutation = {
   updatePermissionPolicy?: Maybe<UpdatePermissionPolicyPayload>;
   /** Updates a single `PermissionPolicy` using a unique key and a patch. */
   updatePermissionPolicyByName?: Maybe<UpdatePermissionPolicyPayload>;
-  /** Updates a single `ProductApplicationJoin` using its globally unique id and a patch. */
-  updateProductApplicationJoinByNodeId?: Maybe<UpdateProductApplicationJoinPayload>;
-  /** Updates a single `ProductApplicationJoin` using a unique key and a patch. */
-  updateProductApplicationJoin?: Maybe<UpdateProductApplicationJoinPayload>;
   /** Updates a single `Review` using its globally unique id and a patch. */
   updateReviewByNodeId?: Maybe<UpdateReviewPayload>;
   /** Updates a single `Review` using a unique key and a patch. */
@@ -15861,12 +17375,6 @@ export type Mutation = {
   updateUserOrganisationByNodeId?: Maybe<UpdateUserOrganisationPayload>;
   /** Updates a single `UserOrganisation` using a unique key and a patch. */
   updateUserOrganisation?: Maybe<UpdateUserOrganisationPayload>;
-  /** Updates a single `UserOrganisation` using a unique key and a patch. */
-  updateUserOrganisationByUserIdAndOrganisationId?: Maybe<UpdateUserOrganisationPayload>;
-  /** Updates a single `UserOrganisationApplicationJoin` using its globally unique id and a patch. */
-  updateUserOrganisationApplicationJoinByNodeId?: Maybe<UpdateUserOrganisationApplicationJoinPayload>;
-  /** Updates a single `UserOrganisationApplicationJoin` using a unique key and a patch. */
-  updateUserOrganisationApplicationJoin?: Maybe<UpdateUserOrganisationApplicationJoinPayload>;
   /** Updates a single `Verification` using its globally unique id and a patch. */
   updateVerificationByNodeId?: Maybe<UpdateVerificationPayload>;
   /** Updates a single `Verification` using a unique key and a patch. */
@@ -15903,6 +17411,12 @@ export type Mutation = {
   deleteApplicationResponseByNodeId?: Maybe<DeleteApplicationResponsePayload>;
   /** Deletes a single `ApplicationResponse` using a unique key. */
   deleteApplicationResponse?: Maybe<DeleteApplicationResponsePayload>;
+  /** Deletes a single `ApplicationReviewerAction` using its globally unique id. */
+  deleteApplicationReviewerActionByNodeId?: Maybe<DeleteApplicationReviewerActionPayload>;
+  /** Deletes a single `ApplicationReviewerAction` using a unique key. */
+  deleteApplicationReviewerAction?: Maybe<DeleteApplicationReviewerActionPayload>;
+  /** Deletes a single `ApplicationReviewerAction` using a unique key. */
+  deleteApplicationReviewerActionByUserIdAndApplicationId?: Maybe<DeleteApplicationReviewerActionPayload>;
   /** Deletes a single `ApplicationStageHistory` using its globally unique id. */
   deleteApplicationStageHistoryByNodeId?: Maybe<DeleteApplicationStageHistoryPayload>;
   /** Deletes a single `ApplicationStageHistory` using a unique key. */
@@ -15927,10 +17441,6 @@ export type Mutation = {
   deleteDataTable?: Maybe<DeleteDataTablePayload>;
   /** Deletes a single `DataTable` using a unique key. */
   deleteDataTableByTableName?: Maybe<DeleteDataTablePayload>;
-  /** Deletes a single `DataTableManufacturingStep` using its globally unique id. */
-  deleteDataTableManufacturingStepByNodeId?: Maybe<DeleteDataTableManufacturingStepPayload>;
-  /** Deletes a single `DataTableManufacturingStep` using a unique key. */
-  deleteDataTableManufacturingStep?: Maybe<DeleteDataTableManufacturingStepPayload>;
   /** Deletes a single `DataTableActiveIngredient` using its globally unique id. */
   deleteDataTableActiveIngredientByNodeId?: Maybe<DeleteDataTableActiveIngredientPayload>;
   /** Deletes a single `DataTableActiveIngredient` using a unique key. */
@@ -15951,10 +17461,6 @@ export type Mutation = {
   deleteDataTableAtcCodeByNodeId?: Maybe<DeleteDataTableAtcCodePayload>;
   /** Deletes a single `DataTableAtcCode` using a unique key. */
   deleteDataTableAtcCode?: Maybe<DeleteDataTableAtcCodePayload>;
-  /** Deletes a single `DataTableAtcTherapeuticCategory` using its globally unique id. */
-  deleteDataTableAtcTherapeuticCategoryByNodeId?: Maybe<DeleteDataTableAtcTherapeuticCategoryPayload>;
-  /** Deletes a single `DataTableAtcTherapeuticCategory` using a unique key. */
-  deleteDataTableAtcTherapeuticCategory?: Maybe<DeleteDataTableAtcTherapeuticCategoryPayload>;
   /** Deletes a single `DataTableContainer` using its globally unique id. */
   deleteDataTableContainerByNodeId?: Maybe<DeleteDataTableContainerPayload>;
   /** Deletes a single `DataTableContainer` using a unique key. */
@@ -15967,26 +17473,54 @@ export type Mutation = {
   deleteDataTableDosageFormByNodeId?: Maybe<DeleteDataTableDosageFormPayload>;
   /** Deletes a single `DataTableDosageForm` using a unique key. */
   deleteDataTableDosageForm?: Maybe<DeleteDataTableDosageFormPayload>;
+  /** Deletes a single `DataTableDosageFormGroup` using its globally unique id. */
+  deleteDataTableDosageFormGroupByNodeId?: Maybe<DeleteDataTableDosageFormGroupPayload>;
+  /** Deletes a single `DataTableDosageFormGroup` using a unique key. */
+  deleteDataTableDosageFormGroup?: Maybe<DeleteDataTableDosageFormGroupPayload>;
   /** Deletes a single `DataTableGenericIngredient` using its globally unique id. */
   deleteDataTableGenericIngredientByNodeId?: Maybe<DeleteDataTableGenericIngredientPayload>;
   /** Deletes a single `DataTableGenericIngredient` using a unique key. */
   deleteDataTableGenericIngredient?: Maybe<DeleteDataTableGenericIngredientPayload>;
-  /** Deletes a single `DataTableIngredientsList` using its globally unique id. */
-  deleteDataTableIngredientsListByNodeId?: Maybe<DeleteDataTableIngredientsListPayload>;
-  /** Deletes a single `DataTableIngredientsList` using a unique key. */
-  deleteDataTableIngredientsList?: Maybe<DeleteDataTableIngredientsListPayload>;
-  /** Deletes a single `DataTableInternationalDiallingPrefix` using its globally unique id. */
-  deleteDataTableInternationalDiallingPrefixByNodeId?: Maybe<DeleteDataTableInternationalDiallingPrefixPayload>;
-  /** Deletes a single `DataTableInternationalDiallingPrefix` using a unique key. */
-  deleteDataTableInternationalDiallingPrefix?: Maybe<DeleteDataTableInternationalDiallingPrefixPayload>;
   /** Deletes a single `DataTableListOfSra` using its globally unique id. */
   deleteDataTableListOfSraByNodeId?: Maybe<DeleteDataTableListOfSraPayload>;
   /** Deletes a single `DataTableListOfSra` using a unique key. */
   deleteDataTableListOfSra?: Maybe<DeleteDataTableListOfSraPayload>;
-  /** Deletes a single `DataTableManufacturingStepsSimpler` using its globally unique id. */
-  deleteDataTableManufacturingStepsSimplerByNodeId?: Maybe<DeleteDataTableManufacturingStepsSimplerPayload>;
-  /** Deletes a single `DataTableManufacturingStepsSimpler` using a unique key. */
-  deleteDataTableManufacturingStepsSimpler?: Maybe<DeleteDataTableManufacturingStepsSimplerPayload>;
+  /** Deletes a single `DataTableManufacturer` using its globally unique id. */
+  deleteDataTableManufacturerByNodeId?: Maybe<DeleteDataTableManufacturerPayload>;
+  /** Deletes a single `DataTableManufacturer` using a unique key. */
+  deleteDataTableManufacturer?: Maybe<DeleteDataTableManufacturerPayload>;
+  /** Deletes a single `DataTableManufacturerApplicationJoin` using its globally unique id. */
+  deleteDataTableManufacturerApplicationJoinByNodeId?: Maybe<DeleteDataTableManufacturerApplicationJoinPayload>;
+  /** Deletes a single `DataTableManufacturerApplicationJoin` using a unique key. */
+  deleteDataTableManufacturerApplicationJoin?: Maybe<DeleteDataTableManufacturerApplicationJoinPayload>;
+  /** Deletes a single `DataTableManufacturerRepresentative` using its globally unique id. */
+  deleteDataTableManufacturerRepresentativeByNodeId?: Maybe<DeleteDataTableManufacturerRepresentativePayload>;
+  /** Deletes a single `DataTableManufacturerRepresentative` using a unique key. */
+  deleteDataTableManufacturerRepresentative?: Maybe<DeleteDataTableManufacturerRepresentativePayload>;
+  /** Deletes a single `DataTableManufacturerRepresentativeApplicationJoin` using its globally unique id. */
+  deleteDataTableManufacturerRepresentativeApplicationJoinByNodeId?: Maybe<DeleteDataTableManufacturerRepresentativeApplicationJoinPayload>;
+  /** Deletes a single `DataTableManufacturerRepresentativeApplicationJoin` using a unique key. */
+  deleteDataTableManufacturerRepresentativeApplicationJoin?: Maybe<DeleteDataTableManufacturerRepresentativeApplicationJoinPayload>;
+  /** Deletes a single `DataTablePermitChemical` using its globally unique id. */
+  deleteDataTablePermitChemicalByNodeId?: Maybe<DeleteDataTablePermitChemicalPayload>;
+  /** Deletes a single `DataTablePermitChemical` using a unique key. */
+  deleteDataTablePermitChemical?: Maybe<DeleteDataTablePermitChemicalPayload>;
+  /** Deletes a single `DataTablePermitChemicalApplicationJoin` using its globally unique id. */
+  deleteDataTablePermitChemicalApplicationJoinByNodeId?: Maybe<DeleteDataTablePermitChemicalApplicationJoinPayload>;
+  /** Deletes a single `DataTablePermitChemicalApplicationJoin` using a unique key. */
+  deleteDataTablePermitChemicalApplicationJoin?: Maybe<DeleteDataTablePermitChemicalApplicationJoinPayload>;
+  /** Deletes a single `DataTablePreRegisteredProductsProvisional` using its globally unique id. */
+  deleteDataTablePreRegisteredProductsProvisionalByNodeId?: Maybe<DeleteDataTablePreRegisteredProductsProvisionalPayload>;
+  /** Deletes a single `DataTablePreRegisteredProductsProvisional` using a unique key. */
+  deleteDataTablePreRegisteredProductsProvisional?: Maybe<DeleteDataTablePreRegisteredProductsProvisionalPayload>;
+  /** Deletes a single `DataTablePrequalManufacturer` using its globally unique id. */
+  deleteDataTablePrequalManufacturerByNodeId?: Maybe<DeleteDataTablePrequalManufacturerPayload>;
+  /** Deletes a single `DataTablePrequalManufacturer` using a unique key. */
+  deleteDataTablePrequalManufacturer?: Maybe<DeleteDataTablePrequalManufacturerPayload>;
+  /** Deletes a single `DataTablePrequalManufacturerApplicationJoin` using its globally unique id. */
+  deleteDataTablePrequalManufacturerApplicationJoinByNodeId?: Maybe<DeleteDataTablePrequalManufacturerApplicationJoinPayload>;
+  /** Deletes a single `DataTablePrequalManufacturerApplicationJoin` using a unique key. */
+  deleteDataTablePrequalManufacturerApplicationJoin?: Maybe<DeleteDataTablePrequalManufacturerApplicationJoinPayload>;
   /** Deletes a single `DataTableProcessingStep` using its globally unique id. */
   deleteDataTableProcessingStepByNodeId?: Maybe<DeleteDataTableProcessingStepPayload>;
   /** Deletes a single `DataTableProcessingStep` using a unique key. */
@@ -15999,10 +17533,18 @@ export type Mutation = {
   deleteDataTableProductApplicationJoinByNodeId?: Maybe<DeleteDataTableProductApplicationJoinPayload>;
   /** Deletes a single `DataTableProductApplicationJoin` using a unique key. */
   deleteDataTableProductApplicationJoin?: Maybe<DeleteDataTableProductApplicationJoinPayload>;
-  /** Deletes a single `DataTableProvince` using its globally unique id. */
-  deleteDataTableProvinceByNodeId?: Maybe<DeleteDataTableProvincePayload>;
-  /** Deletes a single `DataTableProvince` using a unique key. */
-  deleteDataTableProvince?: Maybe<DeleteDataTableProvincePayload>;
+  /** Deletes a single `DataTableProvisionalProduct` using its globally unique id. */
+  deleteDataTableProvisionalProductByNodeId?: Maybe<DeleteDataTableProvisionalProductPayload>;
+  /** Deletes a single `DataTableProvisionalProduct` using a unique key. */
+  deleteDataTableProvisionalProduct?: Maybe<DeleteDataTableProvisionalProductPayload>;
+  /** Deletes a single `DataTableProvisionalProductApplicationJoin` using its globally unique id. */
+  deleteDataTableProvisionalProductApplicationJoinByNodeId?: Maybe<DeleteDataTableProvisionalProductApplicationJoinPayload>;
+  /** Deletes a single `DataTableProvisionalProductApplicationJoin` using a unique key. */
+  deleteDataTableProvisionalProductApplicationJoin?: Maybe<DeleteDataTableProvisionalProductApplicationJoinPayload>;
+  /** Deletes a single `DataTableScheduledChemical` using its globally unique id. */
+  deleteDataTableScheduledChemicalByNodeId?: Maybe<DeleteDataTableScheduledChemicalPayload>;
+  /** Deletes a single `DataTableScheduledChemical` using a unique key. */
+  deleteDataTableScheduledChemical?: Maybe<DeleteDataTableScheduledChemicalPayload>;
   /** Deletes a single `DataTableStorageCondition` using its globally unique id. */
   deleteDataTableStorageConditionByNodeId?: Maybe<DeleteDataTableStorageConditionPayload>;
   /** Deletes a single `DataTableStorageCondition` using a unique key. */
@@ -16043,6 +17585,10 @@ export type Mutation = {
   deleteFilter?: Maybe<DeleteFilterPayload>;
   /** Deletes a single `Filter` using a unique key. */
   deleteFilterByCode?: Maybe<DeleteFilterPayload>;
+  /** Deletes a single `GrafanaDashboardImage` using its globally unique id. */
+  deleteGrafanaDashboardImageByNodeId?: Maybe<DeleteGrafanaDashboardImagePayload>;
+  /** Deletes a single `GrafanaDashboardImage` using a unique key. */
+  deleteGrafanaDashboardImage?: Maybe<DeleteGrafanaDashboardImagePayload>;
   /** Deletes a single `Notification` using its globally unique id. */
   deleteNotificationByNodeId?: Maybe<DeleteNotificationPayload>;
   /** Deletes a single `Notification` using a unique key. */
@@ -16075,10 +17621,6 @@ export type Mutation = {
   deletePermissionPolicy?: Maybe<DeletePermissionPolicyPayload>;
   /** Deletes a single `PermissionPolicy` using a unique key. */
   deletePermissionPolicyByName?: Maybe<DeletePermissionPolicyPayload>;
-  /** Deletes a single `ProductApplicationJoin` using its globally unique id. */
-  deleteProductApplicationJoinByNodeId?: Maybe<DeleteProductApplicationJoinPayload>;
-  /** Deletes a single `ProductApplicationJoin` using a unique key. */
-  deleteProductApplicationJoin?: Maybe<DeleteProductApplicationJoinPayload>;
   /** Deletes a single `Review` using its globally unique id. */
   deleteReviewByNodeId?: Maybe<DeleteReviewPayload>;
   /** Deletes a single `Review` using a unique key. */
@@ -16175,12 +17717,6 @@ export type Mutation = {
   deleteUserOrganisationByNodeId?: Maybe<DeleteUserOrganisationPayload>;
   /** Deletes a single `UserOrganisation` using a unique key. */
   deleteUserOrganisation?: Maybe<DeleteUserOrganisationPayload>;
-  /** Deletes a single `UserOrganisation` using a unique key. */
-  deleteUserOrganisationByUserIdAndOrganisationId?: Maybe<DeleteUserOrganisationPayload>;
-  /** Deletes a single `UserOrganisationApplicationJoin` using its globally unique id. */
-  deleteUserOrganisationApplicationJoinByNodeId?: Maybe<DeleteUserOrganisationApplicationJoinPayload>;
-  /** Deletes a single `UserOrganisationApplicationJoin` using a unique key. */
-  deleteUserOrganisationApplicationJoin?: Maybe<DeleteUserOrganisationApplicationJoinPayload>;
   /** Deletes a single `Verification` using its globally unique id. */
   deleteVerificationByNodeId?: Maybe<DeleteVerificationPayload>;
   /** Deletes a single `Verification` using a unique key. */
@@ -16240,6 +17776,12 @@ export type MutationCreateApplicationResponseArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateApplicationReviewerActionArgs = {
+  input: CreateApplicationReviewerActionInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateApplicationStageHistoryArgs = {
   input: CreateApplicationStageHistoryInput;
 };
@@ -16266,12 +17808,6 @@ export type MutationCreateDataChangelogArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateDataTableArgs = {
   input: CreateDataTableInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableManufacturingStepArgs = {
-  input: CreateDataTableManufacturingStepInput;
 };
 
 
@@ -16306,12 +17842,6 @@ export type MutationCreateDataTableAtcCodeArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableAtcTherapeuticCategoryArgs = {
-  input: CreateDataTableAtcTherapeuticCategoryInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateDataTableContainerArgs = {
   input: CreateDataTableContainerInput;
 };
@@ -16330,20 +17860,14 @@ export type MutationCreateDataTableDosageFormArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableDosageFormGroupArgs = {
+  input: CreateDataTableDosageFormGroupInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateDataTableGenericIngredientArgs = {
   input: CreateDataTableGenericIngredientInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableIngredientsListArgs = {
-  input: CreateDataTableIngredientsListInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableInternationalDiallingPrefixArgs = {
-  input: CreateDataTableInternationalDiallingPrefixInput;
 };
 
 
@@ -16354,8 +17878,56 @@ export type MutationCreateDataTableListOfSraArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableManufacturingStepsSimplerArgs = {
-  input: CreateDataTableManufacturingStepsSimplerInput;
+export type MutationCreateDataTableManufacturerArgs = {
+  input: CreateDataTableManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableManufacturerApplicationJoinArgs = {
+  input: CreateDataTableManufacturerApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableManufacturerRepresentativeArgs = {
+  input: CreateDataTableManufacturerRepresentativeInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableManufacturerRepresentativeApplicationJoinArgs = {
+  input: CreateDataTableManufacturerRepresentativeApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTablePermitChemicalArgs = {
+  input: CreateDataTablePermitChemicalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTablePermitChemicalApplicationJoinArgs = {
+  input: CreateDataTablePermitChemicalApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTablePreRegisteredProductsProvisionalArgs = {
+  input: CreateDataTablePreRegisteredProductsProvisionalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTablePrequalManufacturerArgs = {
+  input: CreateDataTablePrequalManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTablePrequalManufacturerApplicationJoinArgs = {
+  input: CreateDataTablePrequalManufacturerApplicationJoinInput;
 };
 
 
@@ -16378,8 +17950,20 @@ export type MutationCreateDataTableProductApplicationJoinArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateDataTableProvinceArgs = {
-  input: CreateDataTableProvinceInput;
+export type MutationCreateDataTableProvisionalProductArgs = {
+  input: CreateDataTableProvisionalProductInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableProvisionalProductApplicationJoinArgs = {
+  input: CreateDataTableProvisionalProductApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateDataTableScheduledChemicalArgs = {
+  input: CreateDataTableScheduledChemicalInput;
 };
 
 
@@ -16432,6 +18016,12 @@ export type MutationCreateFilterArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateGrafanaDashboardImageArgs = {
+  input: CreateGrafanaDashboardImageInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateNotificationArgs = {
   input: CreateNotificationInput;
 };
@@ -16464,12 +18054,6 @@ export type MutationCreatePermissionNameArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreatePermissionPolicyArgs = {
   input: CreatePermissionPolicyInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateProductApplicationJoinArgs = {
-  input: CreateProductApplicationJoinInput;
 };
 
 
@@ -16606,12 +18190,6 @@ export type MutationCreateUserOrganisationArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateUserOrganisationApplicationJoinArgs = {
-  input: CreateUserOrganisationApplicationJoinInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateVerificationArgs = {
   input: CreateVerificationInput;
 };
@@ -16708,6 +18286,24 @@ export type MutationUpdateApplicationResponseArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateApplicationReviewerActionByNodeIdArgs = {
+  input: UpdateApplicationReviewerActionByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateApplicationReviewerActionArgs = {
+  input: UpdateApplicationReviewerActionInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateApplicationReviewerActionByUserIdAndApplicationIdArgs = {
+  input: UpdateApplicationReviewerActionByUserIdAndApplicationIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateApplicationStageHistoryByNodeIdArgs = {
   input: UpdateApplicationStageHistoryByNodeIdInput;
 };
@@ -16780,18 +18376,6 @@ export type MutationUpdateDataTableByTableNameArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableManufacturingStepByNodeIdArgs = {
-  input: UpdateDataTableManufacturingStepByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableManufacturingStepArgs = {
-  input: UpdateDataTableManufacturingStepInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateDataTableActiveIngredientByNodeIdArgs = {
   input: UpdateDataTableActiveIngredientByNodeIdInput;
 };
@@ -16852,18 +18436,6 @@ export type MutationUpdateDataTableAtcCodeArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableAtcTherapeuticCategoryByNodeIdArgs = {
-  input: UpdateDataTableAtcTherapeuticCategoryByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableAtcTherapeuticCategoryArgs = {
-  input: UpdateDataTableAtcTherapeuticCategoryInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateDataTableContainerByNodeIdArgs = {
   input: UpdateDataTableContainerByNodeIdInput;
 };
@@ -16900,6 +18472,18 @@ export type MutationUpdateDataTableDosageFormArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableDosageFormGroupByNodeIdArgs = {
+  input: UpdateDataTableDosageFormGroupByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableDosageFormGroupArgs = {
+  input: UpdateDataTableDosageFormGroupInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateDataTableGenericIngredientByNodeIdArgs = {
   input: UpdateDataTableGenericIngredientByNodeIdInput;
 };
@@ -16908,30 +18492,6 @@ export type MutationUpdateDataTableGenericIngredientByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateDataTableGenericIngredientArgs = {
   input: UpdateDataTableGenericIngredientInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableIngredientsListByNodeIdArgs = {
-  input: UpdateDataTableIngredientsListByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableIngredientsListArgs = {
-  input: UpdateDataTableIngredientsListInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableInternationalDiallingPrefixByNodeIdArgs = {
-  input: UpdateDataTableInternationalDiallingPrefixByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableInternationalDiallingPrefixArgs = {
-  input: UpdateDataTableInternationalDiallingPrefixInput;
 };
 
 
@@ -16948,14 +18508,110 @@ export type MutationUpdateDataTableListOfSraArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableManufacturingStepsSimplerByNodeIdArgs = {
-  input: UpdateDataTableManufacturingStepsSimplerByNodeIdInput;
+export type MutationUpdateDataTableManufacturerByNodeIdArgs = {
+  input: UpdateDataTableManufacturerByNodeIdInput;
 };
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableManufacturingStepsSimplerArgs = {
-  input: UpdateDataTableManufacturingStepsSimplerInput;
+export type MutationUpdateDataTableManufacturerArgs = {
+  input: UpdateDataTableManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerApplicationJoinByNodeIdArgs = {
+  input: UpdateDataTableManufacturerApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerApplicationJoinArgs = {
+  input: UpdateDataTableManufacturerApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerRepresentativeByNodeIdArgs = {
+  input: UpdateDataTableManufacturerRepresentativeByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerRepresentativeArgs = {
+  input: UpdateDataTableManufacturerRepresentativeInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerRepresentativeApplicationJoinByNodeIdArgs = {
+  input: UpdateDataTableManufacturerRepresentativeApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableManufacturerRepresentativeApplicationJoinArgs = {
+  input: UpdateDataTableManufacturerRepresentativeApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePermitChemicalByNodeIdArgs = {
+  input: UpdateDataTablePermitChemicalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePermitChemicalArgs = {
+  input: UpdateDataTablePermitChemicalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePermitChemicalApplicationJoinByNodeIdArgs = {
+  input: UpdateDataTablePermitChemicalApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePermitChemicalApplicationJoinArgs = {
+  input: UpdateDataTablePermitChemicalApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePreRegisteredProductsProvisionalByNodeIdArgs = {
+  input: UpdateDataTablePreRegisteredProductsProvisionalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePreRegisteredProductsProvisionalArgs = {
+  input: UpdateDataTablePreRegisteredProductsProvisionalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePrequalManufacturerByNodeIdArgs = {
+  input: UpdateDataTablePrequalManufacturerByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePrequalManufacturerArgs = {
+  input: UpdateDataTablePrequalManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePrequalManufacturerApplicationJoinByNodeIdArgs = {
+  input: UpdateDataTablePrequalManufacturerApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTablePrequalManufacturerApplicationJoinArgs = {
+  input: UpdateDataTablePrequalManufacturerApplicationJoinInput;
 };
 
 
@@ -16996,14 +18652,38 @@ export type MutationUpdateDataTableProductApplicationJoinArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableProvinceByNodeIdArgs = {
-  input: UpdateDataTableProvinceByNodeIdInput;
+export type MutationUpdateDataTableProvisionalProductByNodeIdArgs = {
+  input: UpdateDataTableProvisionalProductByNodeIdInput;
 };
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateDataTableProvinceArgs = {
-  input: UpdateDataTableProvinceInput;
+export type MutationUpdateDataTableProvisionalProductArgs = {
+  input: UpdateDataTableProvisionalProductInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableProvisionalProductApplicationJoinByNodeIdArgs = {
+  input: UpdateDataTableProvisionalProductApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableProvisionalProductApplicationJoinArgs = {
+  input: UpdateDataTableProvisionalProductApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableScheduledChemicalByNodeIdArgs = {
+  input: UpdateDataTableScheduledChemicalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateDataTableScheduledChemicalArgs = {
+  input: UpdateDataTableScheduledChemicalInput;
 };
 
 
@@ -17128,6 +18808,18 @@ export type MutationUpdateFilterByCodeArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGrafanaDashboardImageByNodeIdArgs = {
+  input: UpdateGrafanaDashboardImageByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGrafanaDashboardImageArgs = {
+  input: UpdateGrafanaDashboardImageInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateNotificationByNodeIdArgs = {
   input: UpdateNotificationByNodeIdInput;
 };
@@ -17220,18 +18912,6 @@ export type MutationUpdatePermissionPolicyArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdatePermissionPolicyByNameArgs = {
   input: UpdatePermissionPolicyByNameInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateProductApplicationJoinByNodeIdArgs = {
-  input: UpdateProductApplicationJoinByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateProductApplicationJoinArgs = {
-  input: UpdateProductApplicationJoinInput;
 };
 
 
@@ -17524,24 +19204,6 @@ export type MutationUpdateUserOrganisationArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateUserOrganisationByUserIdAndOrganisationIdArgs = {
-  input: UpdateUserOrganisationByUserIdAndOrganisationIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateUserOrganisationApplicationJoinByNodeIdArgs = {
-  input: UpdateUserOrganisationApplicationJoinByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateUserOrganisationApplicationJoinArgs = {
-  input: UpdateUserOrganisationApplicationJoinInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateVerificationByNodeIdArgs = {
   input: UpdateVerificationByNodeIdInput;
 };
@@ -17650,6 +19312,24 @@ export type MutationDeleteApplicationResponseArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteApplicationReviewerActionByNodeIdArgs = {
+  input: DeleteApplicationReviewerActionByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteApplicationReviewerActionArgs = {
+  input: DeleteApplicationReviewerActionInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteApplicationReviewerActionByUserIdAndApplicationIdArgs = {
+  input: DeleteApplicationReviewerActionByUserIdAndApplicationIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteApplicationStageHistoryByNodeIdArgs = {
   input: DeleteApplicationStageHistoryByNodeIdInput;
 };
@@ -17722,18 +19402,6 @@ export type MutationDeleteDataTableByTableNameArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableManufacturingStepByNodeIdArgs = {
-  input: DeleteDataTableManufacturingStepByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableManufacturingStepArgs = {
-  input: DeleteDataTableManufacturingStepInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteDataTableActiveIngredientByNodeIdArgs = {
   input: DeleteDataTableActiveIngredientByNodeIdInput;
 };
@@ -17794,18 +19462,6 @@ export type MutationDeleteDataTableAtcCodeArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableAtcTherapeuticCategoryByNodeIdArgs = {
-  input: DeleteDataTableAtcTherapeuticCategoryByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableAtcTherapeuticCategoryArgs = {
-  input: DeleteDataTableAtcTherapeuticCategoryInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteDataTableContainerByNodeIdArgs = {
   input: DeleteDataTableContainerByNodeIdInput;
 };
@@ -17842,6 +19498,18 @@ export type MutationDeleteDataTableDosageFormArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableDosageFormGroupByNodeIdArgs = {
+  input: DeleteDataTableDosageFormGroupByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableDosageFormGroupArgs = {
+  input: DeleteDataTableDosageFormGroupInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteDataTableGenericIngredientByNodeIdArgs = {
   input: DeleteDataTableGenericIngredientByNodeIdInput;
 };
@@ -17850,30 +19518,6 @@ export type MutationDeleteDataTableGenericIngredientByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteDataTableGenericIngredientArgs = {
   input: DeleteDataTableGenericIngredientInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableIngredientsListByNodeIdArgs = {
-  input: DeleteDataTableIngredientsListByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableIngredientsListArgs = {
-  input: DeleteDataTableIngredientsListInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableInternationalDiallingPrefixByNodeIdArgs = {
-  input: DeleteDataTableInternationalDiallingPrefixByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableInternationalDiallingPrefixArgs = {
-  input: DeleteDataTableInternationalDiallingPrefixInput;
 };
 
 
@@ -17890,14 +19534,110 @@ export type MutationDeleteDataTableListOfSraArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableManufacturingStepsSimplerByNodeIdArgs = {
-  input: DeleteDataTableManufacturingStepsSimplerByNodeIdInput;
+export type MutationDeleteDataTableManufacturerByNodeIdArgs = {
+  input: DeleteDataTableManufacturerByNodeIdInput;
 };
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableManufacturingStepsSimplerArgs = {
-  input: DeleteDataTableManufacturingStepsSimplerInput;
+export type MutationDeleteDataTableManufacturerArgs = {
+  input: DeleteDataTableManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerApplicationJoinByNodeIdArgs = {
+  input: DeleteDataTableManufacturerApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerApplicationJoinArgs = {
+  input: DeleteDataTableManufacturerApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerRepresentativeByNodeIdArgs = {
+  input: DeleteDataTableManufacturerRepresentativeByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerRepresentativeArgs = {
+  input: DeleteDataTableManufacturerRepresentativeInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerRepresentativeApplicationJoinByNodeIdArgs = {
+  input: DeleteDataTableManufacturerRepresentativeApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableManufacturerRepresentativeApplicationJoinArgs = {
+  input: DeleteDataTableManufacturerRepresentativeApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePermitChemicalByNodeIdArgs = {
+  input: DeleteDataTablePermitChemicalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePermitChemicalArgs = {
+  input: DeleteDataTablePermitChemicalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePermitChemicalApplicationJoinByNodeIdArgs = {
+  input: DeleteDataTablePermitChemicalApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePermitChemicalApplicationJoinArgs = {
+  input: DeleteDataTablePermitChemicalApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePreRegisteredProductsProvisionalByNodeIdArgs = {
+  input: DeleteDataTablePreRegisteredProductsProvisionalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePreRegisteredProductsProvisionalArgs = {
+  input: DeleteDataTablePreRegisteredProductsProvisionalInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePrequalManufacturerByNodeIdArgs = {
+  input: DeleteDataTablePrequalManufacturerByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePrequalManufacturerArgs = {
+  input: DeleteDataTablePrequalManufacturerInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePrequalManufacturerApplicationJoinByNodeIdArgs = {
+  input: DeleteDataTablePrequalManufacturerApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTablePrequalManufacturerApplicationJoinArgs = {
+  input: DeleteDataTablePrequalManufacturerApplicationJoinInput;
 };
 
 
@@ -17938,14 +19678,38 @@ export type MutationDeleteDataTableProductApplicationJoinArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableProvinceByNodeIdArgs = {
-  input: DeleteDataTableProvinceByNodeIdInput;
+export type MutationDeleteDataTableProvisionalProductByNodeIdArgs = {
+  input: DeleteDataTableProvisionalProductByNodeIdInput;
 };
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteDataTableProvinceArgs = {
-  input: DeleteDataTableProvinceInput;
+export type MutationDeleteDataTableProvisionalProductArgs = {
+  input: DeleteDataTableProvisionalProductInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableProvisionalProductApplicationJoinByNodeIdArgs = {
+  input: DeleteDataTableProvisionalProductApplicationJoinByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableProvisionalProductApplicationJoinArgs = {
+  input: DeleteDataTableProvisionalProductApplicationJoinInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableScheduledChemicalByNodeIdArgs = {
+  input: DeleteDataTableScheduledChemicalByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteDataTableScheduledChemicalArgs = {
+  input: DeleteDataTableScheduledChemicalInput;
 };
 
 
@@ -18070,6 +19834,18 @@ export type MutationDeleteFilterByCodeArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGrafanaDashboardImageByNodeIdArgs = {
+  input: DeleteGrafanaDashboardImageByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGrafanaDashboardImageArgs = {
+  input: DeleteGrafanaDashboardImageInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteNotificationByNodeIdArgs = {
   input: DeleteNotificationByNodeIdInput;
 };
@@ -18162,18 +19938,6 @@ export type MutationDeletePermissionPolicyArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeletePermissionPolicyByNameArgs = {
   input: DeletePermissionPolicyByNameInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteProductApplicationJoinByNodeIdArgs = {
-  input: DeleteProductApplicationJoinByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteProductApplicationJoinArgs = {
-  input: DeleteProductApplicationJoinInput;
 };
 
 
@@ -18466,24 +20230,6 @@ export type MutationDeleteUserOrganisationArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteUserOrganisationByUserIdAndOrganisationIdArgs = {
-  input: DeleteUserOrganisationByUserIdAndOrganisationIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteUserOrganisationApplicationJoinByNodeIdArgs = {
-  input: DeleteUserOrganisationApplicationJoinByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteUserOrganisationApplicationJoinArgs = {
-  input: DeleteUserOrganisationApplicationJoinInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteVerificationByNodeIdArgs = {
   input: DeleteVerificationByNodeIdInput;
 };
@@ -18731,6 +20477,8 @@ export type UpdateApplicationOnTriggerQueueForTriggerQueueApplicationIdFkeyPatch
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -18742,16 +20490,20 @@ export type UpdateApplicationOnTriggerQueueForTriggerQueueApplicationIdFkeyPatch
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `template` in the `ApplicationInput` mutation. */
@@ -19046,6 +20798,8 @@ export type UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -19057,16 +20811,20 @@ export type UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `user` in the `ApplicationInput` mutation. */
@@ -19144,11 +20902,6 @@ export type UpdateUserOnApplicationForApplicationUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -19164,6 +20917,7 @@ export type UpdateUserOnApplicationForApplicationUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `application` in the `UserInput` mutation. */
@@ -19218,6 +20972,8 @@ export type UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -19229,16 +20985,20 @@ export type UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `organisation` in the `ApplicationInput` mutation. */
@@ -19329,19 +21089,22 @@ export type UpdateOrganisationOnApplicationForApplicationOrgIdFkeyPatch = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -19404,6 +21167,8 @@ export type UpdateApplicationOnApplicationForApplicationOrgIdFkeyPatch = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -19415,16 +21180,20 @@ export type UpdateApplicationOnApplicationForApplicationOrgIdFkeyPatch = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `reviewAssignment` in the `ApplicationInput` mutation. */
@@ -19551,11 +21320,6 @@ export type UpdateUserOnReviewAssignmentForReviewAssignmentAssignerIdFkeyPatch =
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -19571,6 +21335,7 @@ export type UpdateUserOnReviewAssignmentForReviewAssignmentAssignerIdFkeyPatch =
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `reviewAssignment` in the `UserInput` mutation. */
@@ -19675,11 +21440,6 @@ export type UpdateUserOnReviewAssignmentForReviewAssignmentReviewerIdFkeyPatch =
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -19695,6 +21455,7 @@ export type UpdateUserOnReviewAssignmentForReviewAssignmentReviewerIdFkeyPatch =
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `reviewAssignment` in the `UserInput` mutation. */
@@ -19802,19 +21563,22 @@ export type UpdateOrganisationOnReviewAssignmentForReviewAssignmentOrganisationI
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -20120,6 +21884,8 @@ export type UpdateApplicationOnReviewAssignmentForReviewAssignmentApplicationIdF
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -20131,16 +21897,20 @@ export type UpdateApplicationOnReviewAssignmentForReviewAssignmentApplicationIdF
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `review` in the `ApplicationInput` mutation. */
@@ -20923,6 +22693,8 @@ export type UpdateApplicationOnApplicationStageHistoryForApplicationStageHistory
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -20934,16 +22706,20 @@ export type UpdateApplicationOnApplicationStageHistoryForApplicationStageHistory
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `actionQueue` in the `ApplicationInput` mutation. */
@@ -21045,6 +22821,8 @@ export type UpdateApplicationOnActionQueueForActionQueueApplicationIdFkeyPatch =
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -21056,16 +22834,20 @@ export type UpdateApplicationOnActionQueueForActionQueueApplicationIdFkeyPatch =
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `activityLog` in the `ApplicationInput` mutation. */
@@ -21180,6 +22962,8 @@ export type UpdateApplicationOnActivityLogForActivityLogApplicationIdFkeyPatch =
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -21191,16 +22975,20 @@ export type UpdateApplicationOnActivityLogForActivityLogApplicationIdFkeyPatch =
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `applicationNote` in the `ApplicationInput` mutation. */
@@ -21316,6 +23104,8 @@ export type UpdateApplicationOnApplicationNoteForApplicationNoteApplicationIdFke
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -21327,16 +23117,20 @@ export type UpdateApplicationOnApplicationNoteForApplicationNoteApplicationIdFke
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `applicationResponse` in the `ApplicationInput` mutation. */
@@ -21775,11 +23569,6 @@ export type UpdateUserOnFileForFileUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -21795,6 +23584,7 @@ export type UpdateUserOnFileForFileUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `review` in the `UserInput` mutation. */
@@ -21902,6 +23692,8 @@ export type UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -21913,16 +23705,20 @@ export type UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `applicationStageHistory` in the `ApplicationInput` mutation. */
@@ -22196,11 +23992,6 @@ export type UpdateUserOnReviewForReviewReviewerIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -22216,6 +24007,7 @@ export type UpdateUserOnReviewForReviewReviewerIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `applicationNote` in the `UserInput` mutation. */
@@ -22301,11 +24093,6 @@ export type UpdateUserOnApplicationNoteForApplicationNoteUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -22321,6 +24108,7 @@ export type UpdateUserOnApplicationNoteForApplicationNoteUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `reviewAssignmentAssignerJoin` in the `UserInput` mutation. */
@@ -22425,11 +24213,6 @@ export type UpdateUserOnReviewAssignmentAssignerJoinForReviewAssignmentAssignerJ
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -22445,6 +24228,7 @@ export type UpdateUserOnReviewAssignmentAssignerJoinForReviewAssignmentAssignerJ
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `dataChangelog` in the `UserInput` mutation. */
@@ -22558,11 +24342,6 @@ export type UpdateUserOnDataChangelogForDataChangelogUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -22578,6 +24357,7 @@ export type UpdateUserOnDataChangelogForDataChangelogUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `dataChangelog` in the `UserInput` mutation. */
@@ -22672,19 +24452,22 @@ export type UpdateOrganisationOnDataChangelogForDataChangelogOrgIdFkeyPatch = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -22781,19 +24564,22 @@ export type UpdateOrganisationOnApplicationNoteForApplicationNoteOrgIdFkeyPatch 
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -22887,19 +24673,22 @@ export type UpdateOrganisationOnReviewAssignmentAssignerJoinForReviewAssignmentA
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -22998,11 +24787,6 @@ export type UpdateUserOnDataChangelogForDataChangelogUsernameFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -23018,6 +24802,7 @@ export type UpdateUserOnDataChangelogForDataChangelogUsernameFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `file` in the `UserInput` mutation. */
@@ -23506,11 +25291,6 @@ export type UpdateUserOnPermissionJoinForPermissionJoinUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -23526,6 +25306,7 @@ export type UpdateUserOnPermissionJoinForPermissionJoinUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `notification` in the `UserInput` mutation. */
@@ -23638,11 +25419,6 @@ export type UpdateUserOnNotificationForNotificationUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -23658,6 +25434,7 @@ export type UpdateUserOnNotificationForNotificationUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `permissionJoin` in the `UserInput` mutation. */
@@ -23744,19 +25521,22 @@ export type UpdateOrganisationOnPermissionJoinForPermissionJoinOrganisationIdFke
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -23875,6 +25655,8 @@ export type UpdateApplicationOnOrganisationApplicationJoinForOrganisationApplica
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -23886,16 +25668,20 @@ export type UpdateApplicationOnOrganisationApplicationJoinForOrganisationApplica
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `dataChangelog` in the `ApplicationInput` mutation. */
@@ -23995,6 +25781,8 @@ export type UpdateApplicationOnDataChangelogForDataChangelogApplicationIdFkeyPat
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -24006,16 +25794,568 @@ export type UpdateApplicationOnDataChangelogForDataChangelogApplicationIdFkeyPat
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturerApplicationJoin` in the `ApplicationInput` mutation. */
+export type DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableManufacturerApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableManufacturerApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableManufacturerApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingDataTableManufacturerApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyNodeIdUpdate>>;
+  /** A `DataTableManufacturerApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableManufacturerApplicationJoinApplicationIdFkeyDataTableManufacturerApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableManufacturerApplicationJoin` to look up the row to connect. */
+export type DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableManufacturerApplicationJoinNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerApplicationJoin` to look up the row to delete. */
+export type DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableManufacturerApplicationJoinNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerApplicationJoin` to look up the row to update. */
+export type DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingDataTableManufacturerApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+  patch: UpdateDataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+export type UpdateDataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `DataTableManufacturerApplicationJoinInput` mutation. */
+export type DataTableManufacturerApplicationJoinApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturerRepresentativeApplicationJoin` in the `ApplicationInput` mutation. */
+export type DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableManufacturerRepresentativeApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingDataTableManufacturerRepresentativeApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyNodeIdUpdate>>;
+  /** A `DataTableManufacturerRepresentativeApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableManufacturerRepresentativeApplApplicationIdFkeyDataTableManufacturerRepresentativeApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableManufacturerRepresentativeApplicationJoin` to look up the row to connect. */
+export type DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableManufacturerRepresentativeApplicationJoinNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentativeApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerRepresentativeApplicationJoin` to look up the row to delete. */
+export type DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableManufacturerRepresentativeApplicationJoinNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentativeApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerRepresentativeApplicationJoin` to look up the row to update. */
+export type DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingDataTableManufacturerRepresentativeApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: UpdateDataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableManufacturerRepresentativeId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `DataTableManufacturerRepresentativeApplicationJoinInput` mutation. */
+export type DataTableManufacturerRepresentativeApplApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePermitChemicalApplicationJoin` in the `ApplicationInput` mutation. */
+export type DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTablePermitChemicalApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTablePermitChemicalApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTablePermitChemicalApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingDataTablePermitChemicalApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyNodeIdUpdate>>;
+  /** A `DataTablePermitChemicalApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTablePermitChemicalApplicationJoinApplicationIdFkeyDataTablePermitChemicalApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTablePermitChemicalApplicationJoin` to look up the row to connect. */
+export type DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTablePermitChemicalApplicationJoinNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemicalApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePermitChemicalApplicationJoin` to look up the row to delete. */
+export type DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTablePermitChemicalApplicationJoinNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemicalApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePermitChemicalApplicationJoin` to look up the row to update. */
+export type DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingDataTablePermitChemicalApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+  patch: UpdateDataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+export type UpdateDataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dataTablePermitChemicalId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `DataTablePermitChemicalApplicationJoinInput` mutation. */
+export type DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePrequalManufacturerApplicationJoin` in the `ApplicationInput` mutation. */
+export type DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTablePrequalManufacturerApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingDataTablePrequalManufacturerApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyNodeIdUpdate>>;
+  /** A `DataTablePrequalManufacturerApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTablePrequalManufacturerApplicationApplicationIdFkeyDataTablePrequalManufacturerApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTablePrequalManufacturerApplicationJoin` to look up the row to connect. */
+export type DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTablePrequalManufacturerApplicationJoinNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePrequalManufacturerApplicationJoin` to look up the row to delete. */
+export type DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTablePrequalManufacturerApplicationJoinNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturerApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePrequalManufacturerApplicationJoin` to look up the row to update. */
+export type DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingDataTablePrequalManufacturerApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: UpdateDataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dataTablePrequalManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `DataTablePrequalManufacturerApplicationJoinInput` mutation. */
+export type DataTablePrequalManufacturerApplicationApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `dataTableProductApplicationJoin` in the `ApplicationInput` mutation. */
@@ -24072,7 +26412,6 @@ export type UpdateDataTableProductApplicationJoinOnDataTableProductApplicationJo
   id?: Maybe<Scalars['Int']>;
   dataTableProductId?: Maybe<Scalars['Int']>;
   applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
 };
 
 /** Input for the nested mutation of `application` in the `DataTableProductApplicationJoinInput` mutation. */
@@ -24126,6 +26465,8 @@ export type UpdateApplicationOnDataTableProductApplicationJoinForDataTableProduc
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -24137,16 +26478,157 @@ export type UpdateApplicationOnDataTableProductApplicationJoinForDataTableProduc
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableProvisionalProductApplicationJoin` in the `ApplicationInput` mutation. */
+export type DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableProvisionalProductApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableProvisionalProductApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableProvisionalProductApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingDataTableProvisionalProductApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyNodeIdUpdate>>;
+  /** A `DataTableProvisionalProductApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableProvisionalProductApplicationApplicationIdFkeyDataTableProvisionalProductApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableProvisionalProductApplicationJoin` to look up the row to connect. */
+export type DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableProvisionalProductApplicationJoinNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProductApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableProvisionalProductApplicationJoin` to look up the row to delete. */
+export type DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableProvisionalProductApplicationJoinNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProductApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableProvisionalProductApplicationJoin` to look up the row to update. */
+export type DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingDataTableProvisionalProductApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+  patch: UpdateDataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+export type UpdateDataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableProvisionalProductId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `DataTableProvisionalProductApplicationJoinInput` mutation. */
+export type DataTableProvisionalProductApplicationApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `file` in the `ApplicationInput` mutation. */
@@ -24261,6 +26743,8 @@ export type UpdateApplicationOnFileForFileApplicationSerialFkeyPatch = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -24272,16 +26756,20 @@ export type UpdateApplicationOnFileForFileApplicationSerialFkeyPatch = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `notification` in the `ApplicationInput` mutation. */
@@ -24380,6 +26868,8 @@ export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -24391,16 +26881,20 @@ export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `organisationApplicationJoin` in the `ApplicationInput` mutation. */
@@ -24484,19 +26978,22 @@ export type UpdateOrganisationOnOrganisationApplicationJoinForOrganisationApplic
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -25012,6 +27509,8 @@ export type UpdateApplicationOnApplicationResponseForApplicationResponseApplicat
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -25023,146 +27522,20 @@ export type UpdateApplicationOnApplicationResponseForApplicationResponseApplicat
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `productApplicationJoin` in the `ApplicationInput` mutation. */
-export type ProductApplicationJoinApplicationIdFkeyInverseInput = {
-  /** Flag indicating whether all other `productApplicationJoin` records that match this relationship should be removed. */
-  deleteOthers?: Maybe<Scalars['Boolean']>;
-  /** The primary key(s) for `productApplicationJoin` for the far side of the relationship. */
-  connectById?: Maybe<Array<ProductApplicationJoinProductApplicationJoinPkeyConnect>>;
-  /** The primary key(s) for `productApplicationJoin` for the far side of the relationship. */
-  connectByNodeId?: Maybe<Array<ProductApplicationJoinNodeIdConnect>>;
-  /** The primary key(s) for `productApplicationJoin` for the far side of the relationship. */
-  deleteById?: Maybe<Array<ProductApplicationJoinProductApplicationJoinPkeyDelete>>;
-  /** The primary key(s) for `productApplicationJoin` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<Array<ProductApplicationJoinNodeIdDelete>>;
-  /** The primary key(s) and patch data for `productApplicationJoin` for the far side of the relationship. */
-  updateById?: Maybe<Array<ProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingProductApplicationJoinPkeyUpdate>>;
-  /** The primary key(s) and patch data for `productApplicationJoin` for the far side of the relationship. */
-  updateByNodeId?: Maybe<Array<ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyNodeIdUpdate>>;
-  /** A `ProductApplicationJoinInput` object that will be created and connected to this object. */
-  create?: Maybe<Array<ProductApplicationJoinApplicationIdFkeyProductApplicationJoinCreateInput>>;
-};
-
-/** The fields on `productApplicationJoin` to look up the row to connect. */
-export type ProductApplicationJoinProductApplicationJoinPkeyConnect = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to connect. */
-export type ProductApplicationJoinNodeIdConnect = {
-  /** The globally unique `ID` which identifies a single `productApplicationJoin` to be connected. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `productApplicationJoin` to look up the row to delete. */
-export type ProductApplicationJoinProductApplicationJoinPkeyDelete = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to delete. */
-export type ProductApplicationJoinNodeIdDelete = {
-  /** The globally unique `ID` which identifies a single `productApplicationJoin` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `productApplicationJoin` to look up the row to update. */
-export type ProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingProductApplicationJoinPkeyUpdate = {
-  /** An object where the defined keys will be set on the `productApplicationJoin` being updated. */
-  patch: UpdateProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `productApplicationJoin` being updated. */
-export type UpdateProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  productId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<ProductApplicationJoinApplicationIdFkeyInput>;
-};
-
-/** Input for the nested mutation of `application` in the `ProductApplicationJoinInput` mutation. */
-export type ProductApplicationJoinApplicationIdFkeyInput = {
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateById?: Maybe<ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateBySerial?: Maybe<ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateByOutcomeRegistration?: Maybe<ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateByNodeId?: Maybe<ProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyNodeIdUpdate>;
-  /** A `ApplicationInput` object that will be created and connected to this object. */
-  create?: Maybe<ProductApplicationJoinApplicationIdFkeyApplicationCreateInput>;
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `application` being updated. */
-export type UpdateApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `triggerQueue` in the `ApplicationInput` mutation. */
@@ -25460,6 +27833,8 @@ export type UpdateApplicationOnTriggerScheduleForTriggerScheduleApplicationIdFke
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -25471,16 +27846,20 @@ export type UpdateApplicationOnTriggerScheduleForTriggerScheduleApplicationIdFke
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `userApplicationJoin` in the `ApplicationInput` mutation. */
@@ -25591,6 +27970,8 @@ export type UpdateApplicationOnUserApplicationJoinForUserApplicationJoinApplicat
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -25602,147 +27983,20 @@ export type UpdateApplicationOnUserApplicationJoinForUserApplicationJoinApplicat
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `userOrganisationApplicationJoin` in the `ApplicationInput` mutation. */
-export type UserOrganisationApplicationJoinApplicationIdFkeyInverseInput = {
-  /** Flag indicating whether all other `userOrganisationApplicationJoin` records that match this relationship should be removed. */
-  deleteOthers?: Maybe<Scalars['Boolean']>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  connectById?: Maybe<Array<UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyConnect>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  connectByNodeId?: Maybe<Array<UserOrganisationApplicationJoinNodeIdConnect>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  deleteById?: Maybe<Array<UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyDelete>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<Array<UserOrganisationApplicationJoinNodeIdDelete>>;
-  /** The primary key(s) and patch data for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  updateById?: Maybe<Array<UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingUserOrganisationApplicationJoinPkeyUpdate>>;
-  /** The primary key(s) and patch data for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  updateByNodeId?: Maybe<Array<ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyNodeIdUpdate>>;
-  /** A `UserOrganisationApplicationJoinInput` object that will be created and connected to this object. */
-  create?: Maybe<Array<UserOrganisationApplicationJoinApplicationIdFkeyUserOrganisationApplicationJoinCreateInput>>;
-};
-
-/** The fields on `userOrganisationApplicationJoin` to look up the row to connect. */
-export type UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyConnect = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to connect. */
-export type UserOrganisationApplicationJoinNodeIdConnect = {
-  /** The globally unique `ID` which identifies a single `userOrganisationApplicationJoin` to be connected. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `userOrganisationApplicationJoin` to look up the row to delete. */
-export type UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyDelete = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to delete. */
-export type UserOrganisationApplicationJoinNodeIdDelete = {
-  /** The globally unique `ID` which identifies a single `userOrganisationApplicationJoin` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `userOrganisationApplicationJoin` to look up the row to update. */
-export type UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingUserOrganisationApplicationJoinPkeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-  patch: UpdateUserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-export type UpdateUserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  userOrganisationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
-};
-
-/** Input for the nested mutation of `application` in the `UserOrganisationApplicationJoinInput` mutation. */
-export type UserOrganisationApplicationJoinApplicationIdFkeyInput = {
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
-  /** The primary key(s) for `application` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateById?: Maybe<ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateBySerial?: Maybe<ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateByOutcomeRegistration?: Maybe<ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
-  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
-  updateByNodeId?: Maybe<UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyNodeIdUpdate>;
-  /** A `ApplicationInput` object that will be created and connected to this object. */
-  create?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyApplicationCreateInput>;
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationPkeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `application` being updated. */
-export type UpdateApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `verification` in the `ApplicationInput` mutation. */
@@ -25875,6 +28129,8 @@ export type UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -25886,295 +28142,101 @@ export type UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnVerificationForVerificationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch;
-  serial: Scalars['String'];
+/** Input for the nested mutation of `applicationReviewerAction` in the `ApplicationInput` mutation. */
+export type ApplicationReviewerActionApplicationIdFkeyInverseInput = {
+  /** Flag indicating whether all other `applicationReviewerAction` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectById?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionPkeyConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<ApplicationReviewerActionNodeIdConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteById?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionPkeyDelete>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyDelete>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<ApplicationReviewerActionNodeIdDelete>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateById?: Maybe<Array<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationReviewerActionPkeyUpdate>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationReviewerActionUserIdApplicationIdKeyUpdate>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyNodeIdUpdate>>;
+  /** A `ApplicationReviewerActionInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<ApplicationReviewerActionApplicationIdFkeyApplicationReviewerActionCreateInput>>;
 };
 
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnVerificationForVerificationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch;
-  outcomeRegistration: Scalars['String'];
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type VerificationOnVerificationForVerificationApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `application` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: ApplicationPatch;
-};
-
-/** Represents an update to a `Application`. Fields that are set will be updated. */
-export type ApplicationPatch = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** The `application` to be created by this mutation. */
-export type VerificationApplicationIdFkeyApplicationCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** The fields on `verification` to look up the row to update. */
-export type VerificationOnVerificationForVerificationApplicationIdFkeyUsingVerificationUniqueIdKeyUpdate = {
-  /** An object where the defined keys will be set on the `verification` being updated. */
-  patch: UpdateVerificationOnVerificationForVerificationApplicationIdFkeyPatch;
-  uniqueId: Scalars['String'];
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type ApplicationOnVerificationForVerificationApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `verification` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `verification` being updated. */
-  patch: VerificationPatch;
-};
-
-/** Represents an update to a `Verification`. Fields that are set will be updated. */
-export type VerificationPatch = {
-  id?: Maybe<Scalars['Int']>;
-  uniqueId?: Maybe<Scalars['String']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  eventCode?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  data?: Maybe<Scalars['JSON']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
-  timeExpired?: Maybe<Scalars['Datetime']>;
-  isVerified?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  applicationToApplicationId?: Maybe<VerificationApplicationIdFkeyInput>;
-};
-
-/** The `verification` to be created by this mutation. */
-export type VerificationApplicationIdFkeyVerificationCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  uniqueId: Scalars['String'];
-  eventCode?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  data?: Maybe<Scalars['JSON']>;
-  timeCreated?: Maybe<Scalars['Datetime']>;
-  timeExpired?: Maybe<Scalars['Datetime']>;
-  isVerified?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  applicationToApplicationId?: Maybe<VerificationApplicationIdFkeyInput>;
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch;
-  serial: Scalars['String'];
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyPatch;
-  outcomeRegistration: Scalars['String'];
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `application` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: ApplicationPatch;
-};
-
-/** The `application` to be created by this mutation. */
-export type UserOrganisationApplicationJoinApplicationIdFkeyApplicationCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `userOrganisation` in the `UserOrganisationApplicationJoinInput` mutation. */
-export type UserOrganisationApplicationJoinUserOrganisationIdFkeyInput = {
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  connectById?: Maybe<UserOrganisationUserOrganisationPkeyConnect>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  connectByUserIdAndOrganisationId?: Maybe<UserOrganisationUserOrganisationUserIdOrganisationIdKeyConnect>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  connectByNodeId?: Maybe<UserOrganisationNodeIdConnect>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  deleteById?: Maybe<UserOrganisationUserOrganisationPkeyDelete>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  deleteByUserIdAndOrganisationId?: Maybe<UserOrganisationUserOrganisationUserIdOrganisationIdKeyDelete>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<UserOrganisationNodeIdDelete>;
-  /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
-  updateById?: Maybe<UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationPkeyUpdate>;
-  /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
-  updateByUserIdAndOrganisationId?: Maybe<UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate>;
-  /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
-  updateByNodeId?: Maybe<UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyNodeIdUpdate>;
-  /** A `UserOrganisationInput` object that will be created and connected to this object. */
-  create?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyUserOrganisationCreateInput>;
-};
-
-/** The fields on `userOrganisation` to look up the row to connect. */
-export type UserOrganisationUserOrganisationPkeyConnect = {
+/** The fields on `applicationReviewerAction` to look up the row to connect. */
+export type ApplicationReviewerActionApplicationReviewerActionPkeyConnect = {
   id: Scalars['Int'];
 };
 
-/** The fields on `userOrganisation` to look up the row to connect. */
-export type UserOrganisationUserOrganisationUserIdOrganisationIdKeyConnect = {
+/** The fields on `applicationReviewerAction` to look up the row to connect. */
+export type ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyConnect = {
   userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
+  applicationId: Scalars['Int'];
 };
 
 /** The globally unique `ID` look up for the row to connect. */
-export type UserOrganisationNodeIdConnect = {
-  /** The globally unique `ID` which identifies a single `userOrganisation` to be connected. */
+export type ApplicationReviewerActionNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `applicationReviewerAction` to be connected. */
   nodeId: Scalars['ID'];
 };
 
-/** The fields on `userOrganisation` to look up the row to delete. */
-export type UserOrganisationUserOrganisationPkeyDelete = {
+/** The fields on `applicationReviewerAction` to look up the row to delete. */
+export type ApplicationReviewerActionApplicationReviewerActionPkeyDelete = {
   id: Scalars['Int'];
 };
 
-/** The fields on `userOrganisation` to look up the row to delete. */
-export type UserOrganisationUserOrganisationUserIdOrganisationIdKeyDelete = {
+/** The fields on `applicationReviewerAction` to look up the row to delete. */
+export type ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyDelete = {
   userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
+  applicationId: Scalars['Int'];
 };
 
 /** The globally unique `ID` look up for the row to delete. */
-export type UserOrganisationNodeIdDelete = {
-  /** The globally unique `ID` which identifies a single `userOrganisation` to be deleted. */
+export type ApplicationReviewerActionNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `applicationReviewerAction` to be deleted. */
   nodeId: Scalars['ID'];
 };
 
-/** The fields on `userOrganisation` to look up the row to update. */
-export type UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationPkeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisation` being updated. */
-  patch: UpdateUserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyPatch;
+/** The fields on `applicationReviewerAction` to look up the row to update. */
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationReviewerActionPkeyUpdate = {
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch;
   id: Scalars['Int'];
 };
 
-/** An object where the defined keys will be set on the `userOrganisation` being updated. */
-export type UpdateUserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyPatch = {
+/** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+export type UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  organisationId?: Maybe<Scalars['Int']>;
-  userRole?: Maybe<Scalars['String']>;
-  userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
-  organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
 };
 
-/** Input for the nested mutation of `user` in the `UserOrganisationInput` mutation. */
-export type UserOrganisationUserIdFkeyInput = {
+/** Input for the nested mutation of `user` in the `ApplicationReviewerActionInput` mutation. */
+export type ApplicationReviewerActionUserIdFkeyInput = {
   /** The primary key(s) for `user` for the far side of the relationship. */
   connectById?: Maybe<UserUserPkeyConnect>;
   /** The primary key(s) for `user` for the far side of the relationship. */
@@ -26188,24 +28250,24 @@ export type UserOrganisationUserIdFkeyInput = {
   /** The primary key(s) for `user` for the far side of the relationship. */
   deleteByNodeId?: Maybe<UserNodeIdDelete>;
   /** The primary key(s) and patch data for `user` for the far side of the relationship. */
-  updateById?: Maybe<UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserPkeyUpdate>;
+  updateById?: Maybe<UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingUserPkeyUpdate>;
   /** The primary key(s) and patch data for `user` for the far side of the relationship. */
-  updateByUsername?: Maybe<UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserUsernameKeyUpdate>;
+  updateByUsername?: Maybe<UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingUserUsernameKeyUpdate>;
   /** The primary key(s) and patch data for `user` for the far side of the relationship. */
-  updateByNodeId?: Maybe<UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyNodeIdUpdate>;
+  updateByNodeId?: Maybe<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyNodeIdUpdate>;
   /** A `UserInput` object that will be created and connected to this object. */
-  create?: Maybe<UserOrganisationUserIdFkeyUserCreateInput>;
+  create?: Maybe<ApplicationReviewerActionUserIdFkeyUserCreateInput>;
 };
 
 /** The fields on `user` to look up the row to update. */
-export type UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserPkeyUpdate = {
+export type UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingUserPkeyUpdate = {
   /** An object where the defined keys will be set on the `user` being updated. */
-  patch: UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch;
+  patch: UpdateUserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch;
   id: Scalars['Int'];
 };
 
 /** An object where the defined keys will be set on the `user` being updated. */
-export type UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch = {
+export type UpdateUserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
   firstName?: Maybe<Scalars['String']>;
   lastName?: Maybe<Scalars['String']>;
@@ -26216,11 +28278,6 @@ export type UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -26236,6 +28293,7 @@ export type UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `triggerSchedule` in the `UserInput` mutation. */
@@ -26430,11 +28488,6 @@ export type UpdateUserOnTriggerScheduleForTriggerScheduleEditorUserIdFkeyPatch =
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -26450,6 +28503,7 @@ export type UpdateUserOnTriggerScheduleForTriggerScheduleEditorUserIdFkeyPatch =
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `userApplicationJoin` in the `UserInput` mutation. */
@@ -26530,11 +28584,6 @@ export type UpdateUserOnUserApplicationJoinForUserApplicationJoinUserIdFkeyPatch
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -26550,6 +28599,7 @@ export type UpdateUserOnUserApplicationJoinForUserApplicationJoinUserIdFkeyPatch
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `userOrganisation` in the `UserInput` mutation. */
@@ -26559,23 +28609,39 @@ export type UserOrganisationUserIdFkeyInverseInput = {
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   connectById?: Maybe<Array<UserOrganisationUserOrganisationPkeyConnect>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  connectByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationUserOrganisationUserIdOrganisationIdKeyConnect>>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<UserOrganisationNodeIdConnect>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   deleteById?: Maybe<Array<UserOrganisationUserOrganisationPkeyDelete>>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  deleteByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationUserOrganisationUserIdOrganisationIdKeyDelete>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<UserOrganisationNodeIdDelete>>;
   /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
   updateById?: Maybe<Array<UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserOrganisationPkeyUpdate>>;
   /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
-  updateByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate>>;
-  /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<UserOnUserOrganisationForUserOrganisationUserIdFkeyNodeIdUpdate>>;
   /** A `UserOrganisationInput` object that will be created and connected to this object. */
   create?: Maybe<Array<UserOrganisationUserIdFkeyUserOrganisationCreateInput>>;
+};
+
+/** The fields on `userOrganisation` to look up the row to connect. */
+export type UserOrganisationUserOrganisationPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type UserOrganisationNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `userOrganisation` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `userOrganisation` to look up the row to delete. */
+export type UserOrganisationUserOrganisationPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type UserOrganisationNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `userOrganisation` to be deleted. */
+  nodeId: Scalars['ID'];
 };
 
 /** The fields on `userOrganisation` to look up the row to update. */
@@ -26592,7 +28658,410 @@ export type UpdateUserOrganisationOnUserOrganisationForUserOrganisationUserIdFke
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `user` in the `UserOrganisationInput` mutation. */
+export type UserOrganisationUserIdFkeyInput = {
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  connectById?: Maybe<UserUserPkeyConnect>;
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  connectByUsername?: Maybe<UserUserUsernameKeyConnect>;
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  connectByNodeId?: Maybe<UserNodeIdConnect>;
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  deleteById?: Maybe<UserUserPkeyDelete>;
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  deleteByUsername?: Maybe<UserUserUsernameKeyDelete>;
+  /** The primary key(s) for `user` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<UserNodeIdDelete>;
+  /** The primary key(s) and patch data for `user` for the far side of the relationship. */
+  updateById?: Maybe<UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserPkeyUpdate>;
+  /** The primary key(s) and patch data for `user` for the far side of the relationship. */
+  updateByUsername?: Maybe<UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserUsernameKeyUpdate>;
+  /** The primary key(s) and patch data for `user` for the far side of the relationship. */
+  updateByNodeId?: Maybe<UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyNodeIdUpdate>;
+  /** A `UserInput` object that will be created and connected to this object. */
+  create?: Maybe<UserOrganisationUserIdFkeyUserCreateInput>;
+};
+
+/** The fields on `user` to look up the row to update. */
+export type UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserPkeyUpdate = {
+  /** An object where the defined keys will be set on the `user` being updated. */
+  patch: UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `user` being updated. */
+export type UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  dateOfBirth?: Maybe<Scalars['Date']>;
+  passwordHash?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
+  reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
+  reviewAssignmentsToReviewerIdUsingId?: Maybe<ReviewAssignmentReviewerIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewReviewerIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteUserIdFkeyInverseInput>;
+  reviewAssignmentAssignerJoinsUsingId?: Maybe<ReviewAssignmentAssignerJoinAssignerIdFkeyInverseInput>;
+  dataChangelogsToUserIdUsingId?: Maybe<DataChangelogUserIdFkeyInverseInput>;
+  dataChangelogsToUsernameUsingUsername?: Maybe<DataChangelogUsernameFkeyInverseInput>;
+  filesUsingId?: Maybe<FileUserIdFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
+  permissionJoinsUsingId?: Maybe<PermissionJoinUserIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
+  userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `applicationReviewerAction` in the `UserInput` mutation. */
+export type ApplicationReviewerActionUserIdFkeyInverseInput = {
+  /** Flag indicating whether all other `applicationReviewerAction` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectById?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionPkeyConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<ApplicationReviewerActionNodeIdConnect>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteById?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionPkeyDelete>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionApplicationReviewerActionUserIdApplicationIdKeyDelete>>;
+  /** The primary key(s) for `applicationReviewerAction` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<ApplicationReviewerActionNodeIdDelete>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateById?: Maybe<Array<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingApplicationReviewerActionPkeyUpdate>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateByUserIdAndApplicationId?: Maybe<Array<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingApplicationReviewerActionUserIdApplicationIdKeyUpdate>>;
+  /** The primary key(s) and patch data for `applicationReviewerAction` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyNodeIdUpdate>>;
+  /** A `ApplicationReviewerActionInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<ApplicationReviewerActionUserIdFkeyApplicationReviewerActionCreateInput>>;
+};
+
+/** The fields on `applicationReviewerAction` to look up the row to update. */
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingApplicationReviewerActionPkeyUpdate = {
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+export type UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
+};
+
+/** Input for the nested mutation of `application` in the `ApplicationReviewerActionInput` mutation. */
+export type ApplicationReviewerActionApplicationIdFkeyInput = {
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectById?: Maybe<ApplicationApplicationPkeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByOutcomeRegistration?: Maybe<ApplicationApplicationOutcomeRegistrationKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateById?: Maybe<ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByOutcomeRegistration?: Maybe<ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateByNodeId?: Maybe<ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyNodeIdUpdate>;
+  /** A `ApplicationInput` object that will be created and connected to this object. */
+  create?: Maybe<ApplicationReviewerActionApplicationIdFkeyApplicationCreateInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationPkeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `application` being updated. */
+export type UpdateApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** Represents an update to a `Application`. Fields that are set will be updated. */
+export type ApplicationPatch = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** The `application` to be created by this mutation. */
+export type ApplicationReviewerActionApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** The fields on `applicationReviewerAction` to look up the row to update. */
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingApplicationReviewerActionUserIdApplicationIdKeyUpdate = {
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch;
+  userId: Scalars['Int'];
+  applicationId: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `applicationReviewerAction` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: ApplicationReviewerActionPatch;
+};
+
+/** Represents an update to a `ApplicationReviewerAction`. Fields that are set will be updated. */
+export type ApplicationReviewerActionPatch = {
+  id?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
+};
+
+/** The `applicationReviewerAction` to be created by this mutation. */
+export type ApplicationReviewerActionUserIdFkeyApplicationReviewerActionCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
+};
+
+/** The fields on `user` to look up the row to update. */
+export type UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserUsernameKeyUpdate = {
+  /** An object where the defined keys will be set on the `user` being updated. */
+  patch: UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch;
+  username: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `user` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `user` being updated. */
+  patch: UserPatch;
+};
+
+/** Represents an update to a `User`. Fields that are set will be updated. */
+export type UserPatch = {
+  id?: Maybe<Scalars['Int']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  dateOfBirth?: Maybe<Scalars['Date']>;
+  passwordHash?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
+  reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
+  reviewAssignmentsToReviewerIdUsingId?: Maybe<ReviewAssignmentReviewerIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewReviewerIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteUserIdFkeyInverseInput>;
+  reviewAssignmentAssignerJoinsUsingId?: Maybe<ReviewAssignmentAssignerJoinAssignerIdFkeyInverseInput>;
+  dataChangelogsToUserIdUsingId?: Maybe<DataChangelogUserIdFkeyInverseInput>;
+  dataChangelogsToUsernameUsingUsername?: Maybe<DataChangelogUsernameFkeyInverseInput>;
+  filesUsingId?: Maybe<FileUserIdFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
+  permissionJoinsUsingId?: Maybe<PermissionJoinUserIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
+  userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
+};
+
+/** The `user` to be created by this mutation. */
+export type UserOrganisationUserIdFkeyUserCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  dateOfBirth?: Maybe<Scalars['Date']>;
+  passwordHash?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
+  reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
+  reviewAssignmentsToReviewerIdUsingId?: Maybe<ReviewAssignmentReviewerIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewReviewerIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteUserIdFkeyInverseInput>;
+  reviewAssignmentAssignerJoinsUsingId?: Maybe<ReviewAssignmentAssignerJoinAssignerIdFkeyInverseInput>;
+  dataChangelogsToUserIdUsingId?: Maybe<DataChangelogUserIdFkeyInverseInput>;
+  dataChangelogsToUsernameUsingUsername?: Maybe<DataChangelogUsernameFkeyInverseInput>;
+  filesUsingId?: Maybe<FileUserIdFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
+  permissionJoinsUsingId?: Maybe<PermissionJoinUserIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
+  userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `organisation` in the `UserOrganisationInput` mutation. */
@@ -26641,19 +29110,22 @@ export type UpdateOrganisationOnUserOrganisationForUserOrganisationOrganisationI
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -26671,19 +29143,13 @@ export type UserOrganisationOrganisationIdFkeyInverseInput = {
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   connectById?: Maybe<Array<UserOrganisationUserOrganisationPkeyConnect>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  connectByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationUserOrganisationUserIdOrganisationIdKeyConnect>>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<UserOrganisationNodeIdConnect>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   deleteById?: Maybe<Array<UserOrganisationUserOrganisationPkeyDelete>>;
   /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
-  deleteByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationUserOrganisationUserIdOrganisationIdKeyDelete>>;
-  /** The primary key(s) for `userOrganisation` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<UserOrganisationNodeIdDelete>>;
   /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
   updateById?: Maybe<Array<UserOrganisationOnUserOrganisationForUserOrganisationOrganisationIdFkeyUsingUserOrganisationPkeyUpdate>>;
-  /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
-  updateByUserIdAndOrganisationId?: Maybe<Array<UserOrganisationOnUserOrganisationForUserOrganisationOrganisationIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate>>;
   /** The primary key(s) and patch data for `userOrganisation` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<OrganisationOnUserOrganisationForUserOrganisationOrganisationIdFkeyNodeIdUpdate>>;
   /** A `UserOrganisationInput` object that will be created and connected to this object. */
@@ -26704,75 +29170,6 @@ export type UpdateUserOrganisationOnUserOrganisationForUserOrganisationOrganisat
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `userOrganisationApplicationJoin` in the `UserOrganisationInput` mutation. */
-export type UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput = {
-  /** Flag indicating whether all other `userOrganisationApplicationJoin` records that match this relationship should be removed. */
-  deleteOthers?: Maybe<Scalars['Boolean']>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  connectById?: Maybe<Array<UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyConnect>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  connectByNodeId?: Maybe<Array<UserOrganisationApplicationJoinNodeIdConnect>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  deleteById?: Maybe<Array<UserOrganisationApplicationJoinUserOrganisationApplicationJoinPkeyDelete>>;
-  /** The primary key(s) for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<Array<UserOrganisationApplicationJoinNodeIdDelete>>;
-  /** The primary key(s) and patch data for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  updateById?: Maybe<Array<UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationApplicationJoinPkeyUpdate>>;
-  /** The primary key(s) and patch data for `userOrganisationApplicationJoin` for the far side of the relationship. */
-  updateByNodeId?: Maybe<Array<UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyNodeIdUpdate>>;
-  /** A `UserOrganisationApplicationJoinInput` object that will be created and connected to this object. */
-  create?: Maybe<Array<UserOrganisationApplicationJoinUserOrganisationIdFkeyUserOrganisationApplicationJoinCreateInput>>;
-};
-
-/** The fields on `userOrganisationApplicationJoin` to look up the row to update. */
-export type UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationApplicationJoinPkeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-  patch: UpdateUserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-export type UpdateUserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `userOrganisationApplicationJoin` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-  patch: UserOrganisationApplicationJoinPatch;
-};
-
-/** Represents an update to a `UserOrganisationApplicationJoin`. Fields that are set will be updated. */
-export type UserOrganisationApplicationJoinPatch = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  userOrganisationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
-};
-
-/** The `userOrganisationApplicationJoin` to be created by this mutation. */
-export type UserOrganisationApplicationJoinUserOrganisationIdFkeyUserOrganisationApplicationJoinCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
-};
-
-/** The fields on `userOrganisation` to look up the row to update. */
-export type UserOrganisationOnUserOrganisationForUserOrganisationOrganisationIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisation` being updated. */
-  patch: UpdateUserOrganisationOnUserOrganisationForUserOrganisationOrganisationIdFkeyPatch;
-  userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -26791,7 +29188,6 @@ export type UserOrganisationPatch = {
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
 };
 
 /** The `userOrganisation` to be created by this mutation. */
@@ -26801,7 +29197,6 @@ export type UserOrganisationOrganisationIdFkeyUserOrganisationCreateInput = {
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
 };
 
 /** The fields on `organisation` to look up the row to update. */
@@ -26835,19 +29230,22 @@ export type OrganisationPatch = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -26867,19 +29265,22 @@ export type UserOrganisationOrganisationIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -26888,14 +29289,6 @@ export type UserOrganisationOrganisationIdFkeyOrganisationCreateInput = {
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinOrganisationIdFkeyInverseInput>;
   permissionJoinsUsingId?: Maybe<PermissionJoinOrganisationIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationOrganisationIdFkeyInverseInput>;
-};
-
-/** The fields on `userOrganisation` to look up the row to update. */
-export type UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisation` being updated. */
-  patch: UpdateUserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyPatch;
-  userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -26913,7 +29306,6 @@ export type UserOrganisationUserIdFkeyUserOrganisationCreateInput = {
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
 };
 
 /** The fields on `user` to look up the row to update. */
@@ -26931,40 +29323,6 @@ export type UserApplicationJoinOnUserApplicationJoinForUserApplicationJoinUserId
   patch: UserPatch;
 };
 
-/** Represents an update to a `User`. Fields that are set will be updated. */
-export type UserPatch = {
-  id?: Maybe<Scalars['Int']>;
-  firstName?: Maybe<Scalars['String']>;
-  lastName?: Maybe<Scalars['String']>;
-  username?: Maybe<Scalars['String']>;
-  email?: Maybe<Scalars['String']>;
-  dateOfBirth?: Maybe<Scalars['Date']>;
-  passwordHash?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  address?: Maybe<Scalars['String']>;
-  country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
-  fullName?: Maybe<Scalars['String']>;
-  applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
-  reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
-  reviewAssignmentsToReviewerIdUsingId?: Maybe<ReviewAssignmentReviewerIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewReviewerIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteUserIdFkeyInverseInput>;
-  reviewAssignmentAssignerJoinsUsingId?: Maybe<ReviewAssignmentAssignerJoinAssignerIdFkeyInverseInput>;
-  dataChangelogsToUserIdUsingId?: Maybe<DataChangelogUserIdFkeyInverseInput>;
-  dataChangelogsToUsernameUsingUsername?: Maybe<DataChangelogUsernameFkeyInverseInput>;
-  filesUsingId?: Maybe<FileUserIdFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
-  permissionJoinsUsingId?: Maybe<PermissionJoinUserIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
-  userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
-};
-
 /** The `user` to be created by this mutation. */
 export type UserApplicationJoinUserIdFkeyUserCreateInput = {
   id?: Maybe<Scalars['Int']>;
@@ -26977,11 +29335,6 @@ export type UserApplicationJoinUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -26997,6 +29350,7 @@ export type UserApplicationJoinUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -27051,11 +29405,6 @@ export type TriggerScheduleEditorUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -27071,6 +29420,7 @@ export type TriggerScheduleEditorUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -27220,14 +29570,14 @@ export type TriggerScheduleEditorUserIdFkeyTriggerScheduleCreateInput = {
 };
 
 /** The fields on `user` to look up the row to update. */
-export type UserOnUserOrganisationForUserOrganisationUserIdFkeyUsingUserUsernameKeyUpdate = {
+export type UserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyUsingUserUsernameKeyUpdate = {
   /** An object where the defined keys will be set on the `user` being updated. */
-  patch: UpdateUserOnUserOrganisationForUserOrganisationUserIdFkeyPatch;
+  patch: UpdateUserOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyPatch;
   username: Scalars['String'];
 };
 
 /** The globally unique `ID` look up for the row to update. */
-export type UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyNodeIdUpdate = {
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionUserIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `user` to be connected. */
   nodeId: Scalars['ID'];
   /** An object where the defined keys will be set on the `user` being updated. */
@@ -27235,7 +29585,7 @@ export type UserOrganisationOnUserOrganisationForUserOrganisationUserIdFkeyNodeI
 };
 
 /** The `user` to be created by this mutation. */
-export type UserOrganisationUserIdFkeyUserCreateInput = {
+export type ApplicationReviewerActionUserIdFkeyUserCreateInput = {
   id?: Maybe<Scalars['Int']>;
   firstName?: Maybe<Scalars['String']>;
   lastName?: Maybe<Scalars['String']>;
@@ -27246,11 +29596,6 @@ export type UserOrganisationUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -27266,49 +29611,142 @@ export type UserOrganisationUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
-/** The fields on `userOrganisation` to look up the row to update. */
-export type UserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyUsingUserOrganisationUserIdOrganisationIdKeyUpdate = {
-  /** An object where the defined keys will be set on the `userOrganisation` being updated. */
-  patch: UpdateUserOrganisationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyPatch;
+/** The fields on `applicationReviewerAction` to look up the row to update. */
+export type ApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyUsingApplicationReviewerActionUserIdApplicationIdKeyUpdate = {
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: UpdateApplicationReviewerActionOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyPatch;
   userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
+  applicationId: Scalars['Int'];
 };
 
 /** The globally unique `ID` look up for the row to update. */
-export type UserOrganisationApplicationJoinOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinUserOrganisationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `userOrganisation` to be connected. */
+export type ApplicationOnApplicationReviewerActionForApplicationReviewerActionApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `applicationReviewerAction` to be connected. */
   nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `userOrganisation` being updated. */
-  patch: UserOrganisationPatch;
+  /** An object where the defined keys will be set on the `applicationReviewerAction` being updated. */
+  patch: ApplicationReviewerActionPatch;
 };
 
-/** The `userOrganisation` to be created by this mutation. */
-export type UserOrganisationApplicationJoinUserOrganisationIdFkeyUserOrganisationCreateInput = {
+/** The `applicationReviewerAction` to be created by this mutation. */
+export type ApplicationReviewerActionApplicationIdFkeyApplicationReviewerActionCreateInput = {
   id?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  organisationId?: Maybe<Scalars['Int']>;
-  userRole?: Maybe<Scalars['String']>;
-  userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
-  organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnVerificationForVerificationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnVerificationForVerificationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnVerificationForVerificationApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
 };
 
 /** The globally unique `ID` look up for the row to update. */
-export type ApplicationOnUserOrganisationApplicationJoinForUserOrganisationApplicationJoinApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `userOrganisationApplicationJoin` to be connected. */
+export type VerificationOnVerificationForVerificationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
   nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `userOrganisationApplicationJoin` being updated. */
-  patch: UserOrganisationApplicationJoinPatch;
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
 };
 
-/** The `userOrganisationApplicationJoin` to be created by this mutation. */
-export type UserOrganisationApplicationJoinApplicationIdFkeyUserOrganisationApplicationJoinCreateInput = {
+/** The `application` to be created by this mutation. */
+export type VerificationApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  userOrganisationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** The fields on `verification` to look up the row to update. */
+export type VerificationOnVerificationForVerificationApplicationIdFkeyUsingVerificationUniqueIdKeyUpdate = {
+  /** An object where the defined keys will be set on the `verification` being updated. */
+  patch: UpdateVerificationOnVerificationForVerificationApplicationIdFkeyPatch;
+  uniqueId: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnVerificationForVerificationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `verification` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `verification` being updated. */
+  patch: VerificationPatch;
+};
+
+/** Represents an update to a `Verification`. Fields that are set will be updated. */
+export type VerificationPatch = {
+  id?: Maybe<Scalars['Int']>;
+  uniqueId?: Maybe<Scalars['String']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  eventCode?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['JSON']>;
+  timeCreated?: Maybe<Scalars['Datetime']>;
+  timeExpired?: Maybe<Scalars['Datetime']>;
+  isVerified?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  applicationToApplicationId?: Maybe<VerificationApplicationIdFkeyInput>;
+};
+
+/** The `verification` to be created by this mutation. */
+export type VerificationApplicationIdFkeyVerificationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  uniqueId: Scalars['String'];
+  eventCode?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['JSON']>;
+  timeCreated?: Maybe<Scalars['Datetime']>;
+  timeExpired?: Maybe<Scalars['Datetime']>;
+  isVerified?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  applicationToApplicationId?: Maybe<VerificationApplicationIdFkeyInput>;
 };
 
 /** The fields on `application` to look up the row to update. */
@@ -27347,6 +29785,8 @@ export type UserApplicationJoinApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -27358,16 +29798,20 @@ export type UserApplicationJoinApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -27422,6 +29866,8 @@ export type TriggerScheduleApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -27433,16 +29879,20 @@ export type TriggerScheduleApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -27466,88 +29916,6 @@ export type TriggerScheduleApplicationIdFkeyTriggerScheduleCreateInput = {
   applicationToApplicationId?: Maybe<TriggerScheduleApplicationIdFkeyInput>;
   templateToTemplateId?: Maybe<TriggerScheduleTemplateIdFkeyInput>;
   userToEditorUserId?: Maybe<TriggerScheduleEditorUserIdFkeyInput>;
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch;
-  serial: Scalars['String'];
-};
-
-/** The fields on `application` to look up the row to update. */
-export type ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: UpdateApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyPatch;
-  outcomeRegistration: Scalars['String'];
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type ProductApplicationJoinOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `application` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `application` being updated. */
-  patch: ApplicationPatch;
-};
-
-/** The `application` to be created by this mutation. */
-export type ProductApplicationJoinApplicationIdFkeyApplicationCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  orgId?: Maybe<Scalars['Int']>;
-  sessionId?: Maybe<Scalars['String']>;
-  serial?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  outcome?: Maybe<ApplicationOutcome>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  isConfig?: Maybe<Scalars['Boolean']>;
-  trigger?: Maybe<Trigger>;
-  outcomeRegistration?: Maybe<Scalars['String']>;
-  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
-  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
-  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
-  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
-  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
-  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
-  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
-  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
-  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
-  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
-  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
-  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
-  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
-  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
-  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
-  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
-  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type ApplicationOnProductApplicationJoinForProductApplicationJoinApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `productApplicationJoin` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `productApplicationJoin` being updated. */
-  patch: ProductApplicationJoinPatch;
-};
-
-/** Represents an update to a `ProductApplicationJoin`. Fields that are set will be updated. */
-export type ProductApplicationJoinPatch = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  productId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<ProductApplicationJoinApplicationIdFkeyInput>;
-};
-
-/** The `productApplicationJoin` to be created by this mutation. */
-export type ProductApplicationJoinApplicationIdFkeyProductApplicationJoinCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  productId: Scalars['Int'];
-  applicationToApplicationId?: Maybe<ProductApplicationJoinApplicationIdFkeyInput>;
 };
 
 /** The fields on `application` to look up the row to update. */
@@ -27586,6 +29954,8 @@ export type ApplicationResponseApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -27597,16 +29967,20 @@ export type ApplicationResponseApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** Input for the nested mutation of `file` in the `ApplicationResponseInput` mutation. */
@@ -27779,6 +30153,7 @@ export type UpdateReviewResponseOnReviewResponseForReviewResponseApplicationResp
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -27918,6 +30293,7 @@ export type UpdateReviewResponseOnReviewResponseForReviewResponseReviewResponseL
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -27967,6 +30343,7 @@ export type UpdateReviewResponseOnReviewResponseForReviewResponseOriginalReviewR
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28391,6 +30768,7 @@ export type UpdateReviewResponseOnReviewResponseForReviewResponseReviewIdFkeyPat
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28498,6 +30876,7 @@ export type UpdateReviewResponseOnReviewResponseForReviewResponseTemplateElement
   isLatestReview?: Maybe<Scalars['Boolean']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28531,6 +30910,7 @@ export type ReviewResponsePatch = {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28555,6 +30935,7 @@ export type ReviewResponseTemplateElementIdFkeyReviewResponseCreateInput = {
   isLatestReview?: Maybe<Scalars['Boolean']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28654,6 +31035,7 @@ export type ReviewResponseReviewIdFkeyReviewResponseCreateInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28955,6 +31337,7 @@ export type ReviewResponseOriginalReviewResponseIdFkeyReviewResponseCreateInput 
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -28987,6 +31370,7 @@ export type ReviewResponseReviewResponseLinkIdFkeyReviewResponseCreateInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -29019,6 +31403,7 @@ export type ReviewResponseApplicationResponseIdFkeyReviewResponseCreateInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -29831,19 +32216,22 @@ export type OrganisationApplicationJoinOrganisationIdFkeyOrganisationCreateInput
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -29915,6 +32303,8 @@ export type NotificationApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -29926,16 +32316,20 @@ export type NotificationApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -30000,6 +32394,8 @@ export type FileApplicationSerialFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -30011,16 +32407,20 @@ export type FileApplicationSerialFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The fields on `file` to look up the row to update. */
@@ -30067,6 +32467,319 @@ export type FileApplicationSerialFkeyFileCreateInput = {
 };
 
 /** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** The `application` to be created by this mutation. */
+export type DataTableProvisionalProductApplicationApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableProvisionalProduct` in the `DataTableProvisionalProductApplicationJoinInput` mutation. */
+export type DataTableProvisionalProducDataTableProvisionalProduFkeyInput = {
+  /** The primary key(s) for `dataTableProvisionalProduct` for the far side of the relationship. */
+  connectById?: Maybe<DataTableProvisionalProductDataTableProvisionalProductPkeyConnect>;
+  /** The primary key(s) for `dataTableProvisionalProduct` for the far side of the relationship. */
+  connectByNodeId?: Maybe<DataTableProvisionalProductNodeIdConnect>;
+  /** The primary key(s) for `dataTableProvisionalProduct` for the far side of the relationship. */
+  deleteById?: Maybe<DataTableProvisionalProductDataTableProvisionalProductPkeyDelete>;
+  /** The primary key(s) for `dataTableProvisionalProduct` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<DataTableProvisionalProductNodeIdDelete>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProduct` for the far side of the relationship. */
+  updateById?: Maybe<DataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyUsingDataTableProvisionalProductPkeyUpdate>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProduct` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyNodeIdUpdate>;
+  /** A `DataTableProvisionalProductInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyDataTableProvisionalProductCreateInput>;
+};
+
+/** The fields on `dataTableProvisionalProduct` to look up the row to connect. */
+export type DataTableProvisionalProductDataTableProvisionalProductPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableProvisionalProductNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProduct` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableProvisionalProduct` to look up the row to delete. */
+export type DataTableProvisionalProductDataTableProvisionalProductPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableProvisionalProductNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProduct` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableProvisionalProduct` to look up the row to update. */
+export type DataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyUsingDataTableProvisionalProductPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableProvisionalProduct` being updated. */
+  patch: UpdateDataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableProvisionalProduct` being updated. */
+export type UpdateDataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  fullName?: Maybe<Scalars['String']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  productId?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  originalId?: Maybe<Scalars['String']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  registeredIn?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  atcCode?: Maybe<Scalars['JSON']>;
+  pharmacopeia?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  prequalified?: Maybe<Scalars['Boolean']>;
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  loaSource?: Maybe<Scalars['String']>;
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableProvisionalProductApplicationJoin` in the `DataTableProvisionalProductInput` mutation. */
+export type DataTableProvisionalProducDataTableProvisionalProduFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableProvisionalProductApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableProvisionalProductApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableProvisionalProductApplicationJoinDataTableProvisionalProductApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableProvisionalProductApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyUsingDataTableProvisionalProductApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableProvisionalProductApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<DataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyNodeIdUpdate>>;
+  /** A `DataTableProvisionalProductApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableProvisionalProducDataTableProvisionalProduFkeyDataTableProvisionalProductApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableProvisionalProductApplicationJoin` to look up the row to update. */
+export type DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyUsingDataTableProvisionalProductApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+  patch: UpdateDataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+export type UpdateDataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableProvisionalProductOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProductApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+  patch: DataTableProvisionalProductApplicationJoinPatch;
+};
+
+/** Represents an update to a `DataTableProvisionalProductApplicationJoin`. Fields that are set will be updated. */
+export type DataTableProvisionalProductApplicationJoinPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableProvisionalProductId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** The `dataTableProvisionalProductApplicationJoin` to be created by this mutation. */
+export type DataTableProvisionalProducDataTableProvisionalProduFkeyDataTableProvisionalProductApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableProvisionalProductApplicationJoinOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProducDataTableProvisionalProduFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProduct` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableProvisionalProduct` being updated. */
+  patch: DataTableProvisionalProductPatch;
+};
+
+/** Represents an update to a `DataTableProvisionalProduct`. Fields that are set will be updated. */
+export type DataTableProvisionalProductPatch = {
+  id?: Maybe<Scalars['Int']>;
+  fullName?: Maybe<Scalars['String']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  productId?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  originalId?: Maybe<Scalars['String']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  registeredIn?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  atcCode?: Maybe<Scalars['JSON']>;
+  pharmacopeia?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  prequalified?: Maybe<Scalars['Boolean']>;
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  loaSource?: Maybe<Scalars['String']>;
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInverseInput>;
+};
+
+/** The `dataTableProvisionalProduct` to be created by this mutation. */
+export type DataTableProvisionalProducDataTableProvisionalProduFkeyDataTableProvisionalProductCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  fullName?: Maybe<Scalars['String']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  productId?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  originalId?: Maybe<Scalars['String']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  registeredIn?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  atcCode?: Maybe<Scalars['JSON']>;
+  pharmacopeia?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  prequalified?: Maybe<Scalars['Boolean']>;
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  loaSource?: Maybe<Scalars['String']>;
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInverseInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnDataTableProvisionalProductApplicationJoinForDataTableProvisionalProductApplicationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableProvisionalProductApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableProvisionalProductApplicationJoin` being updated. */
+  patch: DataTableProvisionalProductApplicationJoinPatch;
+};
+
+/** The `dataTableProvisionalProductApplicationJoin` to be created by this mutation. */
+export type DataTableProvisionalProductApplicationApplicationIdFkeyDataTableProvisionalProductApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableProvisionalProductId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
 export type ApplicationOnDataTableProductApplicationJoinForDataTableProductApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
   /** An object where the defined keys will be set on the `application` being updated. */
   patch: UpdateApplicationOnDataTableProductApplicationJoinForDataTableProductApplicationJoinApplicationIdFkeyPatch;
@@ -30102,6 +32815,8 @@ export type DataTableProductApplicationJoinApplicationIdFkeyApplicationCreateInp
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -30113,139 +32828,24 @@ export type DataTableProductApplicationJoinApplicationIdFkeyApplicationCreateInp
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `dataTableProduct` in the `DataTableProductApplicationJoinInput` mutation. */
-export type DataTableProductApplicationJoinDataTableProductIdFkeyInput = {
-  /** The primary key(s) for `dataTableProduct` for the far side of the relationship. */
-  connectById?: Maybe<DataTableProductDataTableProductPkeyConnect>;
-  /** The primary key(s) for `dataTableProduct` for the far side of the relationship. */
-  connectByNodeId?: Maybe<DataTableProductNodeIdConnect>;
-  /** The primary key(s) for `dataTableProduct` for the far side of the relationship. */
-  deleteById?: Maybe<DataTableProductDataTableProductPkeyDelete>;
-  /** The primary key(s) for `dataTableProduct` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<DataTableProductNodeIdDelete>;
-  /** The primary key(s) and patch data for `dataTableProduct` for the far side of the relationship. */
-  updateById?: Maybe<DataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyUsingDataTableProductPkeyUpdate>;
-  /** The primary key(s) and patch data for `dataTableProduct` for the far side of the relationship. */
-  updateByNodeId?: Maybe<DataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyNodeIdUpdate>;
-  /** A `DataTableProductInput` object that will be created and connected to this object. */
-  create?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyDataTableProductCreateInput>;
-};
-
-/** The fields on `dataTableProduct` to look up the row to connect. */
-export type DataTableProductDataTableProductPkeyConnect = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to connect. */
-export type DataTableProductNodeIdConnect = {
-  /** The globally unique `ID` which identifies a single `dataTableProduct` to be connected. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `dataTableProduct` to look up the row to delete. */
-export type DataTableProductDataTableProductPkeyDelete = {
-  id: Scalars['Int'];
-};
-
-/** The globally unique `ID` look up for the row to delete. */
-export type DataTableProductNodeIdDelete = {
-  /** The globally unique `ID` which identifies a single `dataTableProduct` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The fields on `dataTableProduct` to look up the row to update. */
-export type DataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyUsingDataTableProductPkeyUpdate = {
-  /** An object where the defined keys will be set on the `dataTableProduct` being updated. */
-  patch: UpdateDataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `dataTableProduct` being updated. */
-export type UpdateDataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  origin?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  expiryDate?: Maybe<Scalars['Datetime']>;
-  registration?: Maybe<Scalars['String']>;
-  applicantName?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  responsiblePerson?: Maybe<Scalars['JSON']>;
-  name?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  atcClass?: Maybe<Scalars['String']>;
-  companyId?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Scalars['JSON']>;
-  dosageForm?: Maybe<Scalars['String']>;
-  applicantId?: Maybe<Scalars['Int']>;
-  companyName?: Maybe<Scalars['String']>;
-  formulations?: Maybe<Scalars['JSON']>;
-  prescription?: Maybe<Scalars['String']>;
-  genericNames?: Maybe<Scalars['JSON']>;
-  medicineType?: Maybe<Scalars['String']>;
-  applicationType?: Maybe<Scalars['String']>;
-  primaryContainer?: Maybe<Scalars['String']>;
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  administrationRoute?: Maybe<Scalars['String']>;
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInverseInput>;
-};
-
-/** Input for the nested mutation of `dataTableProductApplicationJoin` in the `DataTableProductInput` mutation. */
-export type DataTableProductApplicationJoinDataTableProductIdFkeyInverseInput = {
-  /** Flag indicating whether all other `dataTableProductApplicationJoin` records that match this relationship should be removed. */
-  deleteOthers?: Maybe<Scalars['Boolean']>;
-  /** The primary key(s) for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  connectById?: Maybe<Array<DataTableProductApplicationJoinDataTableProductApplicationJoinPkeyConnect>>;
-  /** The primary key(s) for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  connectByNodeId?: Maybe<Array<DataTableProductApplicationJoinNodeIdConnect>>;
-  /** The primary key(s) for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  deleteById?: Maybe<Array<DataTableProductApplicationJoinDataTableProductApplicationJoinPkeyDelete>>;
-  /** The primary key(s) for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  deleteByNodeId?: Maybe<Array<DataTableProductApplicationJoinNodeIdDelete>>;
-  /** The primary key(s) and patch data for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  updateById?: Maybe<Array<DataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyUsingDataTableProductApplicationJoinPkeyUpdate>>;
-  /** The primary key(s) and patch data for `dataTableProductApplicationJoin` for the far side of the relationship. */
-  updateByNodeId?: Maybe<Array<DataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyNodeIdUpdate>>;
-  /** A `DataTableProductApplicationJoinInput` object that will be created and connected to this object. */
-  create?: Maybe<Array<DataTableProductApplicationJoinDataTableProductIdFkeyDataTableProductApplicationJoinCreateInput>>;
-};
-
-/** The fields on `dataTableProductApplicationJoin` to look up the row to update. */
-export type DataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyUsingDataTableProductApplicationJoinPkeyUpdate = {
-  /** An object where the defined keys will be set on the `dataTableProductApplicationJoin` being updated. */
-  patch: UpdateDataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyPatch;
-  id: Scalars['Int'];
-};
-
-/** An object where the defined keys will be set on the `dataTableProductApplicationJoin` being updated. */
-export type UpdateDataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyPatch = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
-export type DataTableProductOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyNodeIdUpdate = {
+export type ApplicationOnDataTableProductApplicationJoinForDataTableProductApplicationJoinApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `dataTableProductApplicationJoin` to be connected. */
   nodeId: Scalars['ID'];
   /** An object where the defined keys will be set on the `dataTableProductApplicationJoin` being updated. */
@@ -30258,113 +32858,983 @@ export type DataTableProductApplicationJoinPatch = {
   applicationId?: Maybe<Scalars['Int']>;
   dataTableProductId?: Maybe<Scalars['Int']>;
   applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
-};
-
-/** The `dataTableProductApplicationJoin` to be created by this mutation. */
-export type DataTableProductApplicationJoinDataTableProductIdFkeyDataTableProductApplicationJoinCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type DataTableProductApplicationJoinOnDataTableProductApplicationJoinForDataTableProductApplicationJoinDataTableProductIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `dataTableProduct` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `dataTableProduct` being updated. */
-  patch: DataTableProductPatch;
-};
-
-/** Represents an update to a `DataTableProduct`. Fields that are set will be updated. */
-export type DataTableProductPatch = {
-  id?: Maybe<Scalars['Int']>;
-  origin?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  expiryDate?: Maybe<Scalars['Datetime']>;
-  registration?: Maybe<Scalars['String']>;
-  applicantName?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  responsiblePerson?: Maybe<Scalars['JSON']>;
-  name?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  atcClass?: Maybe<Scalars['String']>;
-  companyId?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Scalars['JSON']>;
-  dosageForm?: Maybe<Scalars['String']>;
-  applicantId?: Maybe<Scalars['Int']>;
-  companyName?: Maybe<Scalars['String']>;
-  formulations?: Maybe<Scalars['JSON']>;
-  prescription?: Maybe<Scalars['String']>;
-  genericNames?: Maybe<Scalars['JSON']>;
-  medicineType?: Maybe<Scalars['String']>;
-  applicationType?: Maybe<Scalars['String']>;
-  primaryContainer?: Maybe<Scalars['String']>;
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  administrationRoute?: Maybe<Scalars['String']>;
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInverseInput>;
-};
-
-/** The `dataTableProduct` to be created by this mutation. */
-export type DataTableProductApplicationJoinDataTableProductIdFkeyDataTableProductCreateInput = {
-  id?: Maybe<Scalars['Int']>;
-  origin?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  expiryDate?: Maybe<Scalars['Datetime']>;
-  registration?: Maybe<Scalars['String']>;
-  applicantName?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  responsiblePerson?: Maybe<Scalars['JSON']>;
-  name?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  atcClass?: Maybe<Scalars['String']>;
-  companyId?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Scalars['JSON']>;
-  dosageForm?: Maybe<Scalars['String']>;
-  applicantId?: Maybe<Scalars['Int']>;
-  companyName?: Maybe<Scalars['String']>;
-  formulations?: Maybe<Scalars['JSON']>;
-  prescription?: Maybe<Scalars['String']>;
-  genericNames?: Maybe<Scalars['JSON']>;
-  medicineType?: Maybe<Scalars['String']>;
-  applicationType?: Maybe<Scalars['String']>;
-  primaryContainer?: Maybe<Scalars['String']>;
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  administrationRoute?: Maybe<Scalars['String']>;
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInverseInput>;
-};
-
-/** The globally unique `ID` look up for the row to update. */
-export type ApplicationOnDataTableProductApplicationJoinForDataTableProductApplicationJoinApplicationIdFkeyNodeIdUpdate = {
-  /** The globally unique `ID` which identifies a single `dataTableProductApplicationJoin` to be connected. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `dataTableProductApplicationJoin` being updated. */
-  patch: DataTableProductApplicationJoinPatch;
 };
 
 /** The `dataTableProductApplicationJoin` to be created by this mutation. */
 export type DataTableProductApplicationJoinApplicationIdFkeyDataTableProductApplicationJoinCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  dataTableProductId?: Maybe<Scalars['Int']>;
+  dataTableProductId: Scalars['Int'];
   applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** The `application` to be created by this mutation. */
+export type DataTablePrequalManufacturerApplicationApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePrequalManufacturer` in the `DataTablePrequalManufacturerApplicationJoinInput` mutation. */
+export type DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput = {
+  /** The primary key(s) for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  connectById?: Maybe<DataTablePrequalManufacturerDataTablePrequalManufacturerPkeyConnect>;
+  /** The primary key(s) for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  connectByNodeId?: Maybe<DataTablePrequalManufacturerNodeIdConnect>;
+  /** The primary key(s) for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  deleteById?: Maybe<DataTablePrequalManufacturerDataTablePrequalManufacturerPkeyDelete>;
+  /** The primary key(s) for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<DataTablePrequalManufacturerNodeIdDelete>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  updateById?: Maybe<DataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyUsingDataTablePrequalManufacturerPkeyUpdate>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturer` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyNodeIdUpdate>;
+  /** A `DataTablePrequalManufacturerInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyDataTablePrequalManufacturerCreateInput>;
+};
+
+/** The fields on `dataTablePrequalManufacturer` to look up the row to connect. */
+export type DataTablePrequalManufacturerDataTablePrequalManufacturerPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTablePrequalManufacturerNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturer` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePrequalManufacturer` to look up the row to delete. */
+export type DataTablePrequalManufacturerDataTablePrequalManufacturerPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTablePrequalManufacturerNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturer` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePrequalManufacturer` to look up the row to update. */
+export type DataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyUsingDataTablePrequalManufacturerPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturer` being updated. */
+  patch: UpdateDataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePrequalManufacturer` being updated. */
+export type UpdateDataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  lookupId?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  manufacturerId?: Maybe<Scalars['String']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  permitNo?: Maybe<Scalars['String']>;
+  dateIssued?: Maybe<Scalars['String']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePrequalManufacturerApplicationJoin` in the `DataTablePrequalManufacturerInput` mutation. */
+export type DataTablePrequalManufacturDataTablePrequalManufactuFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTablePrequalManufacturerApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinDataTablePrequalManufacturerApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyUsingDataTablePrequalManufacturerApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTablePrequalManufacturerApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<DataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyNodeIdUpdate>>;
+  /** A `DataTablePrequalManufacturerApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTablePrequalManufacturDataTablePrequalManufactuFkeyDataTablePrequalManufacturerApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTablePrequalManufacturerApplicationJoin` to look up the row to update. */
+export type DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyUsingDataTablePrequalManufacturerApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: UpdateDataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePrequalManufacturerOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: DataTablePrequalManufacturerApplicationJoinPatch;
+};
+
+/** Represents an update to a `DataTablePrequalManufacturerApplicationJoin`. Fields that are set will be updated. */
+export type DataTablePrequalManufacturerApplicationJoinPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTablePrequalManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** The `dataTablePrequalManufacturerApplicationJoin` to be created by this mutation. */
+export type DataTablePrequalManufacturDataTablePrequalManufactuFkeyDataTablePrequalManufacturerApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePrequalManufacturerApplicationJoinOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturDataTablePrequalManufactuFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturer` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturer` being updated. */
+  patch: DataTablePrequalManufacturerPatch;
+};
+
+/** Represents an update to a `DataTablePrequalManufacturer`. Fields that are set will be updated. */
+export type DataTablePrequalManufacturerPatch = {
+  id?: Maybe<Scalars['Int']>;
+  lookupId?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  manufacturerId?: Maybe<Scalars['String']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  permitNo?: Maybe<Scalars['String']>;
+  dateIssued?: Maybe<Scalars['String']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInverseInput>;
+};
+
+/** The `dataTablePrequalManufacturer` to be created by this mutation. */
+export type DataTablePrequalManufacturDataTablePrequalManufactuFkeyDataTablePrequalManufacturerCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  lookupId?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  manufacturerId?: Maybe<Scalars['String']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  permitNo?: Maybe<Scalars['String']>;
+  dateIssued?: Maybe<Scalars['String']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInverseInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnDataTablePrequalManufacturerApplicationJoinForDataTablePrequalManufacturerApplicationApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePrequalManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: DataTablePrequalManufacturerApplicationJoinPatch;
+};
+
+/** The `dataTablePrequalManufacturerApplicationJoin` to be created by this mutation. */
+export type DataTablePrequalManufacturerApplicationApplicationIdFkeyDataTablePrequalManufacturerApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  dataTablePrequalManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** The `application` to be created by this mutation. */
+export type DataTablePermitChemicalApplicationJoinApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePermitChemical` in the `DataTablePermitChemicalApplicationJoinInput` mutation. */
+export type DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput = {
+  /** The primary key(s) for `dataTablePermitChemical` for the far side of the relationship. */
+  connectById?: Maybe<DataTablePermitChemicalDataTablePermitChemicalPkeyConnect>;
+  /** The primary key(s) for `dataTablePermitChemical` for the far side of the relationship. */
+  connectByNodeId?: Maybe<DataTablePermitChemicalNodeIdConnect>;
+  /** The primary key(s) for `dataTablePermitChemical` for the far side of the relationship. */
+  deleteById?: Maybe<DataTablePermitChemicalDataTablePermitChemicalPkeyDelete>;
+  /** The primary key(s) for `dataTablePermitChemical` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<DataTablePermitChemicalNodeIdDelete>;
+  /** The primary key(s) and patch data for `dataTablePermitChemical` for the far side of the relationship. */
+  updateById?: Maybe<DataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyUsingDataTablePermitChemicalPkeyUpdate>;
+  /** The primary key(s) and patch data for `dataTablePermitChemical` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyNodeIdUpdate>;
+  /** A `DataTablePermitChemicalInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyDataTablePermitChemicalCreateInput>;
+};
+
+/** The fields on `dataTablePermitChemical` to look up the row to connect. */
+export type DataTablePermitChemicalDataTablePermitChemicalPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTablePermitChemicalNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemical` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePermitChemical` to look up the row to delete. */
+export type DataTablePermitChemicalDataTablePermitChemicalPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTablePermitChemicalNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemical` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTablePermitChemical` to look up the row to update. */
+export type DataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyUsingDataTablePermitChemicalPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePermitChemical` being updated. */
+  patch: UpdateDataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePermitChemical` being updated. */
+export type UpdateDataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  permitNo?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  chemicals?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTablePermitChemicalApplicationJoin` in the `DataTablePermitChemicalInput` mutation. */
+export type DataTablePermitChemicalApDataTablePermitChemicalIFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTablePermitChemicalApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTablePermitChemicalApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTablePermitChemicalApplicationJoinDataTablePermitChemicalApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTablePermitChemicalApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyUsingDataTablePermitChemicalApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTablePermitChemicalApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<DataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyNodeIdUpdate>>;
+  /** A `DataTablePermitChemicalApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTablePermitChemicalApDataTablePermitChemicalIFkeyDataTablePermitChemicalApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTablePermitChemicalApplicationJoin` to look up the row to update. */
+export type DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyUsingDataTablePermitChemicalApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+  patch: UpdateDataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+export type UpdateDataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePermitChemicalOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemicalApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+  patch: DataTablePermitChemicalApplicationJoinPatch;
+};
+
+/** Represents an update to a `DataTablePermitChemicalApplicationJoin`. Fields that are set will be updated. */
+export type DataTablePermitChemicalApplicationJoinPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTablePermitChemicalId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** The `dataTablePermitChemicalApplicationJoin` to be created by this mutation. */
+export type DataTablePermitChemicalApDataTablePermitChemicalIFkeyDataTablePermitChemicalApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTablePermitChemicalApplicationJoinOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApDataTablePermitChemicalIFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemical` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePermitChemical` being updated. */
+  patch: DataTablePermitChemicalPatch;
+};
+
+/** Represents an update to a `DataTablePermitChemical`. Fields that are set will be updated. */
+export type DataTablePermitChemicalPatch = {
+  id?: Maybe<Scalars['Int']>;
+  permitNo?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  chemicals?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInverseInput>;
+};
+
+/** The `dataTablePermitChemical` to be created by this mutation. */
+export type DataTablePermitChemicalApDataTablePermitChemicalIFkeyDataTablePermitChemicalCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  permitNo?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  chemicals?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInverseInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnDataTablePermitChemicalApplicationJoinForDataTablePermitChemicalApplicationJoinApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTablePermitChemicalApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTablePermitChemicalApplicationJoin` being updated. */
+  patch: DataTablePermitChemicalApplicationJoinPatch;
+};
+
+/** The `dataTablePermitChemicalApplicationJoin` to be created by this mutation. */
+export type DataTablePermitChemicalApplicationJoinApplicationIdFkeyDataTablePermitChemicalApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  dataTablePermitChemicalId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** The `application` to be created by this mutation. */
+export type DataTableManufacturerRepresentativeApplApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturerRepresentative` in the `DataTableManufacturerRepresentativeApplicationJoinInput` mutation. */
+export type DataTableManufacturerRepreDataTableManufacturerReprFkeyInput = {
+  /** The primary key(s) for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  connectById?: Maybe<DataTableManufacturerRepresentativeDataTableManufacturerRepresentativePkeyConnect>;
+  /** The primary key(s) for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  connectByNodeId?: Maybe<DataTableManufacturerRepresentativeNodeIdConnect>;
+  /** The primary key(s) for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  deleteById?: Maybe<DataTableManufacturerRepresentativeDataTableManufacturerRepresentativePkeyDelete>;
+  /** The primary key(s) for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<DataTableManufacturerRepresentativeNodeIdDelete>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  updateById?: Maybe<DataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyUsingDataTableManufacturerRepresentativePkeyUpdate>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentative` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyNodeIdUpdate>;
+  /** A `DataTableManufacturerRepresentativeInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyDataTableManufacturerRepresentativeCreateInput>;
+};
+
+/** The fields on `dataTableManufacturerRepresentative` to look up the row to connect. */
+export type DataTableManufacturerRepresentativeDataTableManufacturerRepresentativePkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableManufacturerRepresentativeNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentative` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerRepresentative` to look up the row to delete. */
+export type DataTableManufacturerRepresentativeDataTableManufacturerRepresentativePkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableManufacturerRepresentativeNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentative` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturerRepresentative` to look up the row to update. */
+export type DataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyUsingDataTableManufacturerRepresentativePkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentative` being updated. */
+  patch: UpdateDataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturerRepresentative` being updated. */
+export type UpdateDataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  evaluationNotes?: Maybe<Scalars['String']>;
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturerRepresentativeApplicationJoin` in the `DataTableManufacturerRepresentativeInput` mutation. */
+export type DataTableManufacturerRepreDataTableManufacturerReprFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableManufacturerRepresentativeApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinDataTableManufacturerRepresentativeApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyUsingDataTableManufacturerRepresentativeApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerRepresentativeApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<DataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyNodeIdUpdate>>;
+  /** A `DataTableManufacturerRepresentativeApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableManufacturerRepreDataTableManufacturerReprFkeyDataTableManufacturerRepresentativeApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableManufacturerRepresentativeApplicationJoin` to look up the row to update. */
+export type DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyUsingDataTableManufacturerRepresentativeApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: UpdateDataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerRepresentativeOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentativeApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: DataTableManufacturerRepresentativeApplicationJoinPatch;
+};
+
+/** Represents an update to a `DataTableManufacturerRepresentativeApplicationJoin`. Fields that are set will be updated. */
+export type DataTableManufacturerRepresentativeApplicationJoinPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableManufacturerRepresentativeId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** The `dataTableManufacturerRepresentativeApplicationJoin` to be created by this mutation. */
+export type DataTableManufacturerRepreDataTableManufacturerReprFkeyDataTableManufacturerRepresentativeApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerRepresentativeApplicationJoinOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepreDataTableManufacturerReprFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentative` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentative` being updated. */
+  patch: DataTableManufacturerRepresentativePatch;
+};
+
+/** Represents an update to a `DataTableManufacturerRepresentative`. Fields that are set will be updated. */
+export type DataTableManufacturerRepresentativePatch = {
+  id?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  evaluationNotes?: Maybe<Scalars['String']>;
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInverseInput>;
+};
+
+/** The `dataTableManufacturerRepresentative` to be created by this mutation. */
+export type DataTableManufacturerRepreDataTableManufacturerReprFkeyDataTableManufacturerRepresentativeCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  evaluationNotes?: Maybe<Scalars['String']>;
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInverseInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnDataTableManufacturerRepresentativeApplicationJoinForDataTableManufacturerRepresentativeApplApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerRepresentativeApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: DataTableManufacturerRepresentativeApplicationJoinPatch;
+};
+
+/** The `dataTableManufacturerRepresentativeApplicationJoin` to be created by this mutation. */
+export type DataTableManufacturerRepresentativeApplApplicationIdFkeyDataTableManufacturerRepresentativeApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableManufacturerRepresentativeId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyUsingApplicationOutcomeRegistrationKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyPatch;
+  outcomeRegistration: Scalars['String'];
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `application` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: ApplicationPatch;
+};
+
+/** The `application` to be created by this mutation. */
+export type DataTableManufacturerApplicationJoinApplicationIdFkeyApplicationCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  orgId?: Maybe<Scalars['Int']>;
+  sessionId?: Maybe<Scalars['String']>;
+  serial?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  outcome?: Maybe<ApplicationOutcome>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  isConfig?: Maybe<Scalars['Boolean']>;
+  trigger?: Maybe<Trigger>;
+  outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
+  userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
+  organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
+  reviewAssignmentsUsingId?: Maybe<ReviewAssignmentApplicationIdFkeyInverseInput>;
+  reviewsUsingId?: Maybe<ReviewApplicationIdFkeyInverseInput>;
+  actionQueuesUsingId?: Maybe<ActionQueueApplicationIdFkeyInverseInput>;
+  activityLogsUsingId?: Maybe<ActivityLogApplicationIdFkeyInverseInput>;
+  applicationNotesUsingId?: Maybe<ApplicationNoteApplicationIdFkeyInverseInput>;
+  applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
+  applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
+  dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
+  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
+  filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
+  notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
+  organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
+  triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
+  triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
+  userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
+  verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturer` in the `DataTableManufacturerApplicationJoinInput` mutation. */
+export type DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput = {
+  /** The primary key(s) for `dataTableManufacturer` for the far side of the relationship. */
+  connectById?: Maybe<DataTableManufacturerDataTableManufacturerPkeyConnect>;
+  /** The primary key(s) for `dataTableManufacturer` for the far side of the relationship. */
+  connectByNodeId?: Maybe<DataTableManufacturerNodeIdConnect>;
+  /** The primary key(s) for `dataTableManufacturer` for the far side of the relationship. */
+  deleteById?: Maybe<DataTableManufacturerDataTableManufacturerPkeyDelete>;
+  /** The primary key(s) for `dataTableManufacturer` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<DataTableManufacturerNodeIdDelete>;
+  /** The primary key(s) and patch data for `dataTableManufacturer` for the far side of the relationship. */
+  updateById?: Maybe<DataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyUsingDataTableManufacturerPkeyUpdate>;
+  /** The primary key(s) and patch data for `dataTableManufacturer` for the far side of the relationship. */
+  updateByNodeId?: Maybe<DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyNodeIdUpdate>;
+  /** A `DataTableManufacturerInput` object that will be created and connected to this object. */
+  create?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyDataTableManufacturerCreateInput>;
+};
+
+/** The fields on `dataTableManufacturer` to look up the row to connect. */
+export type DataTableManufacturerDataTableManufacturerPkeyConnect = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to connect. */
+export type DataTableManufacturerNodeIdConnect = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturer` to be connected. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturer` to look up the row to delete. */
+export type DataTableManufacturerDataTableManufacturerPkeyDelete = {
+  id: Scalars['Int'];
+};
+
+/** The globally unique `ID` look up for the row to delete. */
+export type DataTableManufacturerNodeIdDelete = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturer` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The fields on `dataTableManufacturer` to look up the row to update. */
+export type DataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyUsingDataTableManufacturerPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturer` being updated. */
+  patch: UpdateDataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturer` being updated. */
+export type UpdateDataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  isAdditional?: Maybe<Scalars['Boolean']>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInverseInput>;
+};
+
+/** Input for the nested mutation of `dataTableManufacturerApplicationJoin` in the `DataTableManufacturerInput` mutation. */
+export type DataTableManufacturerApplicaDataTableManufacturerIdFkeyInverseInput = {
+  /** Flag indicating whether all other `dataTableManufacturerApplicationJoin` records that match this relationship should be removed. */
+  deleteOthers?: Maybe<Scalars['Boolean']>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  connectById?: Maybe<Array<DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyConnect>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  connectByNodeId?: Maybe<Array<DataTableManufacturerApplicationJoinNodeIdConnect>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteById?: Maybe<Array<DataTableManufacturerApplicationJoinDataTableManufacturerApplicationJoinPkeyDelete>>;
+  /** The primary key(s) for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  deleteByNodeId?: Maybe<Array<DataTableManufacturerApplicationJoinNodeIdDelete>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  updateById?: Maybe<Array<DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyUsingDataTableManufacturerApplicationJoinPkeyUpdate>>;
+  /** The primary key(s) and patch data for `dataTableManufacturerApplicationJoin` for the far side of the relationship. */
+  updateByNodeId?: Maybe<Array<DataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyNodeIdUpdate>>;
+  /** A `DataTableManufacturerApplicationJoinInput` object that will be created and connected to this object. */
+  create?: Maybe<Array<DataTableManufacturerApplicaDataTableManufacturerIdFkeyDataTableManufacturerApplicationJoinCreateInput>>;
+};
+
+/** The fields on `dataTableManufacturerApplicationJoin` to look up the row to update. */
+export type DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyUsingDataTableManufacturerApplicationJoinPkeyUpdate = {
+  /** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+  patch: UpdateDataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyPatch;
+  id: Scalars['Int'];
+};
+
+/** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+export type UpdateDataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+  patch: DataTableManufacturerApplicationJoinPatch;
+};
+
+/** Represents an update to a `DataTableManufacturerApplicationJoin`. Fields that are set will be updated. */
+export type DataTableManufacturerApplicationJoinPatch = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
+};
+
+/** The `dataTableManufacturerApplicationJoin` to be created by this mutation. */
+export type DataTableManufacturerApplicaDataTableManufacturerIdFkeyDataTableManufacturerApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type DataTableManufacturerApplicationJoinOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicaDataTableManufacturerIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturer` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturer` being updated. */
+  patch: DataTableManufacturerPatch;
+};
+
+/** Represents an update to a `DataTableManufacturer`. Fields that are set will be updated. */
+export type DataTableManufacturerPatch = {
+  id?: Maybe<Scalars['Int']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  isAdditional?: Maybe<Scalars['Boolean']>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInverseInput>;
+};
+
+/** The `dataTableManufacturer` to be created by this mutation. */
+export type DataTableManufacturerApplicaDataTableManufacturerIdFkeyDataTableManufacturerCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  isAdditional?: Maybe<Scalars['Boolean']>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInverseInput>;
+};
+
+/** The globally unique `ID` look up for the row to update. */
+export type ApplicationOnDataTableManufacturerApplicationJoinForDataTableManufacturerApplicationJoinApplicationIdFkeyNodeIdUpdate = {
+  /** The globally unique `ID` which identifies a single `dataTableManufacturerApplicationJoin` to be connected. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `dataTableManufacturerApplicationJoin` being updated. */
+  patch: DataTableManufacturerApplicationJoinPatch;
+};
+
+/** The `dataTableManufacturerApplicationJoin` to be created by this mutation. */
+export type DataTableManufacturerApplicationJoinApplicationIdFkeyDataTableManufacturerApplicationJoinCreateInput = {
+  id?: Maybe<Scalars['Int']>;
+  dataTableManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
 };
 
 /** The fields on `application` to look up the row to update. */
@@ -30403,6 +33873,8 @@ export type DataChangelogApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -30414,16 +33886,20 @@ export type DataChangelogApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -30509,6 +33985,8 @@ export type OrganisationApplicationJoinApplicationIdFkeyApplicationCreateInput =
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -30520,16 +33998,20 @@ export type OrganisationApplicationJoinApplicationIdFkeyApplicationCreateInput =
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -30579,19 +34061,22 @@ export type PermissionJoinOrganisationIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -30648,11 +34133,6 @@ export type NotificationUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -30668,6 +34148,7 @@ export type NotificationUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -30723,11 +34204,6 @@ export type PermissionJoinUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -30743,6 +34219,7 @@ export type PermissionJoinUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -30997,11 +34474,6 @@ export type DataChangelogUsernameFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -31017,6 +34489,7 @@ export type DataChangelogUsernameFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -31077,19 +34550,22 @@ export type ReviewAssignmentAssignerJoinOrganisationIdFkeyOrganisationCreateInpu
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -31347,19 +34823,22 @@ export type ApplicationNoteOrgIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -31422,19 +34901,22 @@ export type DataChangelogOrgIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -31499,11 +34981,6 @@ export type DataChangelogUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -31519,6 +34996,7 @@ export type DataChangelogUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -31575,11 +35053,6 @@ export type ReviewAssignmentAssignerJoinAssignerIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -31595,6 +35068,7 @@ export type ReviewAssignmentAssignerJoinAssignerIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -31642,11 +35116,6 @@ export type ApplicationNoteUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -31662,6 +35131,7 @@ export type ApplicationNoteUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -31712,11 +35182,6 @@ export type ReviewReviewerIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -31732,6 +35197,7 @@ export type ReviewReviewerIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The fields on `review` to look up the row to update. */
@@ -32089,6 +35555,8 @@ export type ReviewApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -32100,16 +35568,20 @@ export type ReviewApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The fields on `review` to look up the row to update. */
@@ -32175,11 +35647,6 @@ export type FileUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -32195,6 +35662,7 @@ export type FileUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The fields on `file` to look up the row to update. */
@@ -32421,6 +35889,8 @@ export type ApplicationNoteApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -32432,16 +35902,20 @@ export type ApplicationNoteApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -32501,6 +35975,8 @@ export type ActivityLogApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -32512,16 +35988,20 @@ export type ActivityLogApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -32593,6 +36073,8 @@ export type ActionQueueApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -32604,16 +36086,20 @@ export type ActionQueueApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -32681,6 +36167,8 @@ export type ApplicationStageHistoryApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -32692,16 +36180,20 @@ export type ApplicationStageHistoryApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -33155,6 +36647,8 @@ export type ReviewAssignmentApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -33166,16 +36660,20 @@ export type ReviewAssignmentApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -33361,19 +36859,22 @@ export type ReviewAssignmentOrganisationIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -33451,11 +36952,6 @@ export type ReviewAssignmentReviewerIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -33471,6 +36967,7 @@ export type ReviewAssignmentReviewerIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -33540,11 +37037,6 @@ export type ReviewAssignmentAssignerIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -33560,6 +37052,7 @@ export type ReviewAssignmentAssignerIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -33637,6 +37130,8 @@ export type ApplicationOrgIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -33648,16 +37143,20 @@ export type ApplicationOrgIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The fields on `organisation` to look up the row to update. */
@@ -33691,19 +37190,22 @@ export type ApplicationOrgIdFkeyOrganisationCreateInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -33749,6 +37251,8 @@ export type ApplicationUserIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -33760,16 +37264,20 @@ export type ApplicationUserIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The fields on `user` to look up the row to update. */
@@ -33799,11 +37307,6 @@ export type ApplicationUserIdFkeyUserCreateInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -33819,6 +37322,7 @@ export type ApplicationUserIdFkeyUserCreateInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The fields on `application` to look up the row to update. */
@@ -33856,6 +37360,8 @@ export type ApplicationTemplateIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -33867,16 +37373,20 @@ export type ApplicationTemplateIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The fields on `template` to look up the row to update. */
@@ -34053,6 +37563,8 @@ export type TriggerQueueApplicationIdFkeyApplicationCreateInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -34064,16 +37576,20 @@ export type TriggerQueueApplicationIdFkeyApplicationCreateInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The globally unique `ID` look up for the row to update. */
@@ -34222,6 +37738,8 @@ export type ApplicationInput = {
   isConfig?: Maybe<Scalars['Boolean']>;
   trigger?: Maybe<Trigger>;
   outcomeRegistration?: Maybe<Scalars['String']>;
+  reviewerList?: Maybe<Array<Maybe<Scalars['String']>>>;
+  assignerList?: Maybe<Array<Maybe<Scalars['String']>>>;
   templateToTemplateId?: Maybe<ApplicationTemplateIdFkeyInput>;
   userToUserId?: Maybe<ApplicationUserIdFkeyInput>;
   organisationToOrgId?: Maybe<ApplicationOrgIdFkeyInput>;
@@ -34233,16 +37751,20 @@ export type ApplicationInput = {
   applicationResponsesUsingId?: Maybe<ApplicationResponseApplicationIdFkeyInverseInput>;
   applicationStageHistoriesUsingId?: Maybe<ApplicationStageHistoryApplicationIdFkeyInverseInput>;
   dataChangelogsUsingId?: Maybe<DataChangelogApplicationIdFkeyInverseInput>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInverseInput>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInverseInput>;
   dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInverseInput>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInverseInput>;
   filesUsingSerial?: Maybe<FileApplicationSerialFkeyInverseInput>;
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
   organisationApplicationJoinsUsingId?: Maybe<OrganisationApplicationJoinApplicationIdFkeyInverseInput>;
-  productApplicationJoinsUsingId?: Maybe<ProductApplicationJoinApplicationIdFkeyInverseInput>;
   triggerQueuesUsingId?: Maybe<TriggerQueueApplicationIdFkeyInverseInput>;
   triggerSchedulesUsingId?: Maybe<TriggerScheduleApplicationIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinApplicationIdFkeyInverseInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInverseInput>;
   verificationsUsingId?: Maybe<VerificationApplicationIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInverseInput>;
 };
 
 /** The output of our create `Application` mutation. */
@@ -34413,6 +37935,48 @@ export type CreateApplicationResponsePayload = {
 /** The output of our create `ApplicationResponse` mutation. */
 export type CreateApplicationResponsePayloadApplicationResponseEdgeArgs = {
   orderBy?: Maybe<Array<ApplicationResponsesOrderBy>>;
+};
+
+/** All input for the create `ApplicationReviewerAction` mutation. */
+export type CreateApplicationReviewerActionInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `ApplicationReviewerAction` to be created by this mutation. */
+  applicationReviewerAction: ApplicationReviewerActionInput;
+};
+
+/** An input for mutations affecting `ApplicationReviewerAction` */
+export type ApplicationReviewerActionInput = {
+  id?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  reviewerAction?: Maybe<ReviewerAction>;
+  assignerAction?: Maybe<AssignerAction>;
+  userToUserId?: Maybe<ApplicationReviewerActionUserIdFkeyInput>;
+  applicationToApplicationId?: Maybe<ApplicationReviewerActionApplicationIdFkeyInput>;
+};
+
+/** The output of our create `ApplicationReviewerAction` mutation. */
+export type CreateApplicationReviewerActionPayload = {
+  __typename?: 'CreateApplicationReviewerActionPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `ApplicationReviewerAction` that was created by this mutation. */
+  applicationReviewerAction?: Maybe<ApplicationReviewerAction>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `User` that is related to this `ApplicationReviewerAction`. */
+  user?: Maybe<User>;
+  /** Reads a single `Application` that is related to this `ApplicationReviewerAction`. */
+  application?: Maybe<Application>;
+  /** An edge for our `ApplicationReviewerAction`. May be used by Relay 1. */
+  applicationReviewerActionEdge?: Maybe<ApplicationReviewerActionsEdge>;
+};
+
+
+/** The output of our create `ApplicationReviewerAction` mutation. */
+export type CreateApplicationReviewerActionPayloadApplicationReviewerActionEdgeArgs = {
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
 };
 
 /** All input for the create `ApplicationStageHistory` mutation. */
@@ -34624,41 +38188,6 @@ export type CreateDataTablePayloadDataTableEdgeArgs = {
   orderBy?: Maybe<Array<DataTablesOrderBy>>;
 };
 
-/** All input for the create `DataTableManufacturingStep` mutation. */
-export type CreateDataTableManufacturingStepInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStep` to be created by this mutation. */
-  dataTableManufacturingStep: DataTableManufacturingStepInput;
-};
-
-/** An input for mutations affecting `DataTableManufacturingStep` */
-export type DataTableManufacturingStepInput = {
-  id?: Maybe<Scalars['Int']>;
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
-  definition?: Maybe<Scalars['String']>;
-};
-
-/** The output of our create `DataTableManufacturingStep` mutation. */
-export type CreateDataTableManufacturingStepPayload = {
-  __typename?: 'CreateDataTableManufacturingStepPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStep` that was created by this mutation. */
-  dataTableManufacturingStep?: Maybe<DataTableManufacturingStep>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStep`. May be used by Relay 1. */
-  dataTableManufacturingStepEdge?: Maybe<DataTableManufacturingStepsEdge>;
-};
-
-
-/** The output of our create `DataTableManufacturingStep` mutation. */
-export type CreateDataTableManufacturingStepPayloadDataTableManufacturingStepEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsOrderBy>>;
-};
-
 /** All input for the create `DataTableActiveIngredient` mutation. */
 export type CreateDataTableActiveIngredientInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -34672,7 +38201,6 @@ export type DataTableActiveIngredientInput = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   latina?: Maybe<Scalars['String']>;
-  portuguese?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableActiveIngredient` mutation. */
@@ -34706,7 +38234,8 @@ export type CreateDataTableAdministrationRouteInput = {
 export type DataTableAdministrationRouteInput = {
   id?: Maybe<Scalars['Int']>;
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableAdministrationRoute` mutation. */
@@ -34739,7 +38268,7 @@ export type CreateDataTableAnnexInput = {
 /** An input for mutations affecting `DataTableAnnex` */
 export type DataTableAnnexInput = {
   id?: Maybe<Scalars['Int']>;
-  country?: Maybe<Scalars['String']>;
+  nameCommon?: Maybe<Scalars['String']>;
   source?: Maybe<Scalars['String']>;
 };
 
@@ -34832,42 +38361,6 @@ export type CreateDataTableAtcCodePayloadDataTableAtcCodeEdgeArgs = {
   orderBy?: Maybe<Array<DataTableAtcCodesOrderBy>>;
 };
 
-/** All input for the create `DataTableAtcTherapeuticCategory` mutation. */
-export type CreateDataTableAtcTherapeuticCategoryInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableAtcTherapeuticCategory` to be created by this mutation. */
-  dataTableAtcTherapeuticCategory: DataTableAtcTherapeuticCategoryInput;
-};
-
-/** An input for mutations affecting `DataTableAtcTherapeuticCategory` */
-export type DataTableAtcTherapeuticCategoryInput = {
-  id?: Maybe<Scalars['Int']>;
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** The output of our create `DataTableAtcTherapeuticCategory` mutation. */
-export type CreateDataTableAtcTherapeuticCategoryPayload = {
-  __typename?: 'CreateDataTableAtcTherapeuticCategoryPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableAtcTherapeuticCategory` that was created by this mutation. */
-  dataTableAtcTherapeuticCategory?: Maybe<DataTableAtcTherapeuticCategory>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableAtcTherapeuticCategory`. May be used by Relay 1. */
-  dataTableAtcTherapeuticCategoryEdge?: Maybe<DataTableAtcTherapeuticCategoriesEdge>;
-};
-
-
-/** The output of our create `DataTableAtcTherapeuticCategory` mutation. */
-export type CreateDataTableAtcTherapeuticCategoryPayloadDataTableAtcTherapeuticCategoryEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableAtcTherapeuticCategoriesOrderBy>>;
-};
-
 /** All input for the create `DataTableContainer` mutation. */
 export type CreateDataTableContainerInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -34880,7 +38373,8 @@ export type CreateDataTableContainerInput = {
 export type DataTableContainerInput = {
   id?: Maybe<Scalars['Int']>;
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableContainer` mutation. */
@@ -34917,7 +38411,6 @@ export type DataTableCountryInput = {
   nameOfficial?: Maybe<Scalars['String']>;
   translationsPorOfficial?: Maybe<Scalars['String']>;
   translationsPorCommon?: Maybe<Scalars['String']>;
-  translationCommonNoAccent?: Maybe<Scalars['String']>;
   flag?: Maybe<Scalars['String']>;
 };
 
@@ -34951,7 +38444,9 @@ export type CreateDataTableDosageFormInput = {
 /** An input for mutations affecting `DataTableDosageForm` */
 export type DataTableDosageFormInput = {
   id?: Maybe<Scalars['Int']>;
-  dosageForm?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableDosageForm` mutation. */
@@ -34971,6 +38466,39 @@ export type CreateDataTableDosageFormPayload = {
 /** The output of our create `DataTableDosageForm` mutation. */
 export type CreateDataTableDosageFormPayloadDataTableDosageFormEdgeArgs = {
   orderBy?: Maybe<Array<DataTableDosageFormsOrderBy>>;
+};
+
+/** All input for the create `DataTableDosageFormGroup` mutation. */
+export type CreateDataTableDosageFormGroupInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableDosageFormGroup` to be created by this mutation. */
+  dataTableDosageFormGroup: DataTableDosageFormGroupInput;
+};
+
+/** An input for mutations affecting `DataTableDosageFormGroup` */
+export type DataTableDosageFormGroupInput = {
+  id?: Maybe<Scalars['Int']>;
+  dosageFormGroups?: Maybe<Scalars['String']>;
+};
+
+/** The output of our create `DataTableDosageFormGroup` mutation. */
+export type CreateDataTableDosageFormGroupPayload = {
+  __typename?: 'CreateDataTableDosageFormGroupPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableDosageFormGroup` that was created by this mutation. */
+  dataTableDosageFormGroup?: Maybe<DataTableDosageFormGroup>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableDosageFormGroup`. May be used by Relay 1. */
+  dataTableDosageFormGroupEdge?: Maybe<DataTableDosageFormGroupsEdge>;
+};
+
+
+/** The output of our create `DataTableDosageFormGroup` mutation. */
+export type CreateDataTableDosageFormGroupPayloadDataTableDosageFormGroupEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableDosageFormGroupsOrderBy>>;
 };
 
 /** All input for the create `DataTableGenericIngredient` mutation. */
@@ -35011,77 +38539,6 @@ export type CreateDataTableGenericIngredientPayloadDataTableGenericIngredientEdg
   orderBy?: Maybe<Array<DataTableGenericIngredientsOrderBy>>;
 };
 
-/** All input for the create `DataTableIngredientsList` mutation. */
-export type CreateDataTableIngredientsListInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableIngredientsList` to be created by this mutation. */
-  dataTableIngredientsList: DataTableIngredientsListInput;
-};
-
-/** An input for mutations affecting `DataTableIngredientsList` */
-export type DataTableIngredientsListInput = {
-  id?: Maybe<Scalars['Int']>;
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** The output of our create `DataTableIngredientsList` mutation. */
-export type CreateDataTableIngredientsListPayload = {
-  __typename?: 'CreateDataTableIngredientsListPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableIngredientsList` that was created by this mutation. */
-  dataTableIngredientsList?: Maybe<DataTableIngredientsList>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableIngredientsList`. May be used by Relay 1. */
-  dataTableIngredientsListEdge?: Maybe<DataTableIngredientsListsEdge>;
-};
-
-
-/** The output of our create `DataTableIngredientsList` mutation. */
-export type CreateDataTableIngredientsListPayloadDataTableIngredientsListEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableIngredientsListsOrderBy>>;
-};
-
-/** All input for the create `DataTableInternationalDiallingPrefix` mutation. */
-export type CreateDataTableInternationalDiallingPrefixInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableInternationalDiallingPrefix` to be created by this mutation. */
-  dataTableInternationalDiallingPrefix: DataTableInternationalDiallingPrefixInput;
-};
-
-/** An input for mutations affecting `DataTableInternationalDiallingPrefix` */
-export type DataTableInternationalDiallingPrefixInput = {
-  id?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
-  country?: Maybe<Scalars['String']>;
-  display?: Maybe<Scalars['String']>;
-};
-
-/** The output of our create `DataTableInternationalDiallingPrefix` mutation. */
-export type CreateDataTableInternationalDiallingPrefixPayload = {
-  __typename?: 'CreateDataTableInternationalDiallingPrefixPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableInternationalDiallingPrefix` that was created by this mutation. */
-  dataTableInternationalDiallingPrefix?: Maybe<DataTableInternationalDiallingPrefix>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableInternationalDiallingPrefix`. May be used by Relay 1. */
-  dataTableInternationalDiallingPrefixEdge?: Maybe<DataTableInternationalDiallingPrefixesEdge>;
-};
-
-
-/** The output of our create `DataTableInternationalDiallingPrefix` mutation. */
-export type CreateDataTableInternationalDiallingPrefixPayloadDataTableInternationalDiallingPrefixEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableInternationalDiallingPrefixesOrderBy>>;
-};
-
 /** All input for the create `DataTableListOfSra` mutation. */
 export type CreateDataTableListOfSraInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -35115,38 +38572,388 @@ export type CreateDataTableListOfSraPayloadDataTableListOfSraEdgeArgs = {
   orderBy?: Maybe<Array<DataTableListOfSrasOrderBy>>;
 };
 
-/** All input for the create `DataTableManufacturingStepsSimpler` mutation. */
-export type CreateDataTableManufacturingStepsSimplerInput = {
+/** All input for the create `DataTableManufacturer` mutation. */
+export type CreateDataTableManufacturerInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStepsSimpler` to be created by this mutation. */
-  dataTableManufacturingStepsSimpler: DataTableManufacturingStepsSimplerInput;
+  /** The `DataTableManufacturer` to be created by this mutation. */
+  dataTableManufacturer: DataTableManufacturerInput;
 };
 
-/** An input for mutations affecting `DataTableManufacturingStepsSimpler` */
-export type DataTableManufacturingStepsSimplerInput = {
+/** An input for mutations affecting `DataTableManufacturer` */
+export type DataTableManufacturerInput = {
   id?: Maybe<Scalars['Int']>;
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
+  manufacturer?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  isAdditional?: Maybe<Scalars['Boolean']>;
+  dataTableManufacturerApplicationJoinsUsingId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInverseInput>;
 };
 
-/** The output of our create `DataTableManufacturingStepsSimpler` mutation. */
-export type CreateDataTableManufacturingStepsSimplerPayload = {
-  __typename?: 'CreateDataTableManufacturingStepsSimplerPayload';
+/** The output of our create `DataTableManufacturer` mutation. */
+export type CreateDataTableManufacturerPayload = {
+  __typename?: 'CreateDataTableManufacturerPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStepsSimpler` that was created by this mutation. */
-  dataTableManufacturingStepsSimpler?: Maybe<DataTableManufacturingStepsSimpler>;
+  /** The `DataTableManufacturer` that was created by this mutation. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStepsSimpler`. May be used by Relay 1. */
-  dataTableManufacturingStepsSimplerEdge?: Maybe<DataTableManufacturingStepsSimplersEdge>;
+  /** An edge for our `DataTableManufacturer`. May be used by Relay 1. */
+  dataTableManufacturerEdge?: Maybe<DataTableManufacturersEdge>;
 };
 
 
-/** The output of our create `DataTableManufacturingStepsSimpler` mutation. */
-export type CreateDataTableManufacturingStepsSimplerPayloadDataTableManufacturingStepsSimplerEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsSimplersOrderBy>>;
+/** The output of our create `DataTableManufacturer` mutation. */
+export type CreateDataTableManufacturerPayloadDataTableManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturersOrderBy>>;
+};
+
+/** All input for the create `DataTableManufacturerApplicationJoin` mutation. */
+export type CreateDataTableManufacturerApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerApplicationJoin` to be created by this mutation. */
+  dataTableManufacturerApplicationJoin: DataTableManufacturerApplicationJoinInput;
+};
+
+/** An input for mutations affecting `DataTableManufacturerApplicationJoin` */
+export type DataTableManufacturerApplicationJoinInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerApplicationJoinApplicationIdFkeyInput>;
+  dataTableManufacturerToDataTableManufacturerId?: Maybe<DataTableManufacturerApplicaDataTableManufacturerIdFkeyInput>;
+};
+
+/** The output of our create `DataTableManufacturerApplicationJoin` mutation. */
+export type CreateDataTableManufacturerApplicationJoinPayload = {
+  __typename?: 'CreateDataTableManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerApplicationJoin` that was created by this mutation. */
+  dataTableManufacturerApplicationJoin?: Maybe<DataTableManufacturerApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturer` that is related to this `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+  /** An edge for our `DataTableManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerApplicationJoinEdge?: Maybe<DataTableManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our create `DataTableManufacturerApplicationJoin` mutation. */
+export type CreateDataTableManufacturerApplicationJoinPayloadDataTableManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+};
+
+/** All input for the create `DataTableManufacturerRepresentative` mutation. */
+export type CreateDataTableManufacturerRepresentativeInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentative` to be created by this mutation. */
+  dataTableManufacturerRepresentative: DataTableManufacturerRepresentativeInput;
+};
+
+/** An input for mutations affecting `DataTableManufacturerRepresentative` */
+export type DataTableManufacturerRepresentativeInput = {
+  id?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  manufacturerDatabaseId?: Maybe<Scalars['Int']>;
+  manufacturerRegistrationId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  letterOfAuthorization?: Maybe<Scalars['JSON']>;
+  manufacturingCompanies?: Maybe<Scalars['JSON']>;
+  evaluationNotes?: Maybe<Scalars['String']>;
+  gmpByWhoCertificate?: Maybe<Scalars['JSON']>;
+  dataTableManufacturerRepresentativeApplicationJoinsUsingId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInverseInput>;
+};
+
+/** The output of our create `DataTableManufacturerRepresentative` mutation. */
+export type CreateDataTableManufacturerRepresentativePayload = {
+  __typename?: 'CreateDataTableManufacturerRepresentativePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentative` that was created by this mutation. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableManufacturerRepresentative`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeEdge?: Maybe<DataTableManufacturerRepresentativesEdge>;
+};
+
+
+/** The output of our create `DataTableManufacturerRepresentative` mutation. */
+export type CreateDataTableManufacturerRepresentativePayloadDataTableManufacturerRepresentativeEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativesOrderBy>>;
+};
+
+/** All input for the create `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type CreateDataTableManufacturerRepresentativeApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentativeApplicationJoin` to be created by this mutation. */
+  dataTableManufacturerRepresentativeApplicationJoin: DataTableManufacturerRepresentativeApplicationJoinInput;
+};
+
+/** An input for mutations affecting `DataTableManufacturerRepresentativeApplicationJoin` */
+export type DataTableManufacturerRepresentativeApplicationJoinInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableManufacturerRepresentativeId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableManufacturerRepresentativeApplApplicationIdFkeyInput>;
+  dataTableManufacturerRepresentativeToDataTableManufacturerRepresentativeId?: Maybe<DataTableManufacturerRepreDataTableManufacturerReprFkeyInput>;
+};
+
+/** The output of our create `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type CreateDataTableManufacturerRepresentativeApplicationJoinPayload = {
+  __typename?: 'CreateDataTableManufacturerRepresentativeApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentativeApplicationJoin` that was created by this mutation. */
+  dataTableManufacturerRepresentativeApplicationJoin?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturerRepresentative` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  /** An edge for our `DataTableManufacturerRepresentativeApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeApplicationJoinEdge?: Maybe<DataTableManufacturerRepresentativeApplicationJoinsEdge>;
+};
+
+
+/** The output of our create `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type CreateDataTableManufacturerRepresentativeApplicationJoinPayloadDataTableManufacturerRepresentativeApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+};
+
+/** All input for the create `DataTablePermitChemical` mutation. */
+export type CreateDataTablePermitChemicalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemical` to be created by this mutation. */
+  dataTablePermitChemical: DataTablePermitChemicalInput;
+};
+
+/** An input for mutations affecting `DataTablePermitChemical` */
+export type DataTablePermitChemicalInput = {
+  id?: Maybe<Scalars['Int']>;
+  permitNo?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  chemicals?: Maybe<Scalars['JSON']>;
+  companyId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  chemicalsFilterData?: Maybe<Scalars['String']>;
+  dataTablePermitChemicalApplicationJoinsUsingId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInverseInput>;
+};
+
+/** The output of our create `DataTablePermitChemical` mutation. */
+export type CreateDataTablePermitChemicalPayload = {
+  __typename?: 'CreateDataTablePermitChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemical` that was created by this mutation. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePermitChemical`. May be used by Relay 1. */
+  dataTablePermitChemicalEdge?: Maybe<DataTablePermitChemicalsEdge>;
+};
+
+
+/** The output of our create `DataTablePermitChemical` mutation. */
+export type CreateDataTablePermitChemicalPayloadDataTablePermitChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalsOrderBy>>;
+};
+
+/** All input for the create `DataTablePermitChemicalApplicationJoin` mutation. */
+export type CreateDataTablePermitChemicalApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemicalApplicationJoin` to be created by this mutation. */
+  dataTablePermitChemicalApplicationJoin: DataTablePermitChemicalApplicationJoinInput;
+};
+
+/** An input for mutations affecting `DataTablePermitChemicalApplicationJoin` */
+export type DataTablePermitChemicalApplicationJoinInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTablePermitChemicalId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePermitChemicalApplicationJoinApplicationIdFkeyInput>;
+  dataTablePermitChemicalToDataTablePermitChemicalId?: Maybe<DataTablePermitChemicalApDataTablePermitChemicalIFkeyInput>;
+};
+
+/** The output of our create `DataTablePermitChemicalApplicationJoin` mutation. */
+export type CreateDataTablePermitChemicalApplicationJoinPayload = {
+  __typename?: 'CreateDataTablePermitChemicalApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemicalApplicationJoin` that was created by this mutation. */
+  dataTablePermitChemicalApplicationJoin?: Maybe<DataTablePermitChemicalApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePermitChemical` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  /** An edge for our `DataTablePermitChemicalApplicationJoin`. May be used by Relay 1. */
+  dataTablePermitChemicalApplicationJoinEdge?: Maybe<DataTablePermitChemicalApplicationJoinsEdge>;
+};
+
+
+/** The output of our create `DataTablePermitChemicalApplicationJoin` mutation. */
+export type CreateDataTablePermitChemicalApplicationJoinPayloadDataTablePermitChemicalApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+};
+
+/** All input for the create `DataTablePreRegisteredProductsProvisional` mutation. */
+export type CreateDataTablePreRegisteredProductsProvisionalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePreRegisteredProductsProvisional` to be created by this mutation. */
+  dataTablePreRegisteredProductsProvisional: DataTablePreRegisteredProductsProvisionalInput;
+};
+
+/** An input for mutations affecting `DataTablePreRegisteredProductsProvisional` */
+export type DataTablePreRegisteredProductsProvisionalInput = {
+  id?: Maybe<Scalars['Int']>;
+  productIdOriginal?: Maybe<Scalars['String']>;
+  productIdUnique?: Maybe<Scalars['String']>;
+  authority?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  activeIngredientsResponse?: Maybe<Scalars['JSON']>;
+  multipleFormulations?: Maybe<Scalars['Boolean']>;
+  componentsOriginal?: Maybe<Scalars['JSON']>;
+  packSizes?: Maybe<Scalars['JSON']>;
+  packSizesResponse?: Maybe<Scalars['JSON']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  indications?: Maybe<Scalars['String']>;
+  productType?: Maybe<Scalars['String']>;
+  containerType?: Maybe<Scalars['String']>;
+  effectiveDate?: Maybe<Scalars['Date']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  manufacturersResponse?: Maybe<Scalars['JSON']>;
+};
+
+/** The output of our create `DataTablePreRegisteredProductsProvisional` mutation. */
+export type CreateDataTablePreRegisteredProductsProvisionalPayload = {
+  __typename?: 'CreateDataTablePreRegisteredProductsProvisionalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePreRegisteredProductsProvisional` that was created by this mutation. */
+  dataTablePreRegisteredProductsProvisional?: Maybe<DataTablePreRegisteredProductsProvisional>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePreRegisteredProductsProvisional`. May be used by Relay 1. */
+  dataTablePreRegisteredProductsProvisionalEdge?: Maybe<DataTablePreRegisteredProductsProvisionalsEdge>;
+};
+
+
+/** The output of our create `DataTablePreRegisteredProductsProvisional` mutation. */
+export type CreateDataTablePreRegisteredProductsProvisionalPayloadDataTablePreRegisteredProductsProvisionalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePreRegisteredProductsProvisionalsOrderBy>>;
+};
+
+/** All input for the create `DataTablePrequalManufacturer` mutation. */
+export type CreateDataTablePrequalManufacturerInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturer` to be created by this mutation. */
+  dataTablePrequalManufacturer: DataTablePrequalManufacturerInput;
+};
+
+/** An input for mutations affecting `DataTablePrequalManufacturer` */
+export type DataTablePrequalManufacturerInput = {
+  id?: Maybe<Scalars['Int']>;
+  lookupId?: Maybe<Scalars['Int']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  manufacturerId?: Maybe<Scalars['String']>;
+  prequalificationDate?: Maybe<Scalars['Datetime']>;
+  name?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  gmpScope?: Maybe<Scalars['JSON']>;
+  permitNo?: Maybe<Scalars['String']>;
+  dateIssued?: Maybe<Scalars['String']>;
+  manufacturingLicence?: Maybe<Scalars['JSON']>;
+  dataTablePrequalManufacturerApplicationJoinsUsingId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInverseInput>;
+};
+
+/** The output of our create `DataTablePrequalManufacturer` mutation. */
+export type CreateDataTablePrequalManufacturerPayload = {
+  __typename?: 'CreateDataTablePrequalManufacturerPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturer` that was created by this mutation. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePrequalManufacturer`. May be used by Relay 1. */
+  dataTablePrequalManufacturerEdge?: Maybe<DataTablePrequalManufacturersEdge>;
+};
+
+
+/** The output of our create `DataTablePrequalManufacturer` mutation. */
+export type CreateDataTablePrequalManufacturerPayloadDataTablePrequalManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturersOrderBy>>;
+};
+
+/** All input for the create `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type CreateDataTablePrequalManufacturerApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturerApplicationJoin` to be created by this mutation. */
+  dataTablePrequalManufacturerApplicationJoin: DataTablePrequalManufacturerApplicationJoinInput;
+};
+
+/** An input for mutations affecting `DataTablePrequalManufacturerApplicationJoin` */
+export type DataTablePrequalManufacturerApplicationJoinInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTablePrequalManufacturerId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTablePrequalManufacturerApplicationApplicationIdFkeyInput>;
+  dataTablePrequalManufacturerToDataTablePrequalManufacturerId?: Maybe<DataTablePrequalManufacturDataTablePrequalManufactuFkeyInput>;
+};
+
+/** The output of our create `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type CreateDataTablePrequalManufacturerApplicationJoinPayload = {
+  __typename?: 'CreateDataTablePrequalManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturerApplicationJoin` that was created by this mutation. */
+  dataTablePrequalManufacturerApplicationJoin?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePrequalManufacturer` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  /** An edge for our `DataTablePrequalManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTablePrequalManufacturerApplicationJoinEdge?: Maybe<DataTablePrequalManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our create `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type CreateDataTablePrequalManufacturerApplicationJoinPayloadDataTablePrequalManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
 };
 
 /** All input for the create `DataTableProcessingStep` mutation. */
@@ -35160,8 +38967,7 @@ export type CreateDataTableProcessingStepInput = {
 /** An input for mutations affecting `DataTableProcessingStep` */
 export type DataTableProcessingStepInput = {
   id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  processingStep?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableProcessingStep` mutation. */
@@ -35194,38 +39000,35 @@ export type CreateDataTableProductInput = {
 /** An input for mutations affecting `DataTableProduct` */
 export type DataTableProductInput = {
   id?: Maybe<Scalars['Int']>;
-  origin?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
   expiryDate?: Maybe<Scalars['Datetime']>;
-  registration?: Maybe<Scalars['String']>;
-  applicantName?: Maybe<Scalars['String']>;
+  productOrigin?: Maybe<Scalars['String']>;
   registrationDate?: Maybe<Scalars['Datetime']>;
-  responsiblePerson?: Maybe<Scalars['JSON']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  sra?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   atcCode?: Maybe<Scalars['String']>;
-  atcClass?: Maybe<Scalars['String']>;
-  companyId?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Scalars['JSON']>;
+  shelfLife?: Maybe<Scalars['String']>;
   dosageForm?: Maybe<Scalars['String']>;
-  applicantId?: Maybe<Scalars['Int']>;
+  atcCategory?: Maybe<Scalars['String']>;
   companyName?: Maybe<Scalars['String']>;
-  formulations?: Maybe<Scalars['JSON']>;
-  prescription?: Maybe<Scalars['String']>;
-  genericNames?: Maybe<Scalars['JSON']>;
-  medicineType?: Maybe<Scalars['String']>;
-  applicationType?: Maybe<Scalars['String']>;
+  formulations?: Maybe<Scalars['String']>;
+  companyPhone?: Maybe<Scalars['String']>;
+  companyAddress?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  importerAddress?: Maybe<Scalars['String']>;
+  activeSubstances?: Maybe<Scalars['JSON']>;
   primaryContainer?: Maybe<Scalars['String']>;
-  shelfLifeOpened?: Maybe<Scalars['String']>;
-  manufacturersList?: Maybe<Scalars['JSON']>;
-  shelfLifeProposed?: Maybe<Scalars['String']>;
-  administrationRoute?: Maybe<Scalars['String']>;
-  isLocallyManufactured?: Maybe<Scalars['Boolean']>;
-  shelfLifeReconstructed?: Maybe<Scalars['String']>;
-  storageConditionsOpened?: Maybe<Scalars['String']>;
-  storageConditionsProposed?: Maybe<Scalars['String']>;
-  genericNamesFilterData?: Maybe<Scalars['String']>;
-  manufacturersListFilterData?: Maybe<Scalars['String']>;
-  dataTableProductApplicationJoinsUsingId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInverseInput>;
+  administrationUnit?: Maybe<Scalars['String']>;
+  storageTemperature?: Maybe<Scalars['String']>;
+  proposedIndications?: Maybe<Scalars['String']>;
+  componentFormulation?: Maybe<Scalars['String']>;
+  packagingDescription?: Maybe<Scalars['String']>;
+  dosageFormDescription?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  finishedProductManufacturers?: Maybe<Scalars['String']>;
+  nationalMedicalClassification?: Maybe<Scalars['String']>;
+  activeIngredientsManufacturers?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
 };
 
 /** The output of our create `DataTableProduct` mutation. */
@@ -35259,9 +39062,8 @@ export type CreateDataTableProductApplicationJoinInput = {
 export type DataTableProductApplicationJoinInput = {
   id?: Maybe<Scalars['Int']>;
   applicationId?: Maybe<Scalars['Int']>;
-  dataTableProductId?: Maybe<Scalars['Int']>;
+  dataTableProductId: Scalars['Int'];
   applicationToApplicationId?: Maybe<DataTableProductApplicationJoinApplicationIdFkeyInput>;
-  dataTableProductToDataTableProductId?: Maybe<DataTableProductApplicationJoinDataTableProductIdFkeyInput>;
 };
 
 /** The output of our create `DataTableProductApplicationJoin` mutation. */
@@ -35275,8 +39077,6 @@ export type CreateDataTableProductApplicationJoinPayload = {
   query?: Maybe<Query>;
   /** Reads a single `Application` that is related to this `DataTableProductApplicationJoin`. */
   application?: Maybe<Application>;
-  /** Reads a single `DataTableProduct` that is related to this `DataTableProductApplicationJoin`. */
-  dataTableProduct?: Maybe<DataTableProduct>;
   /** An edge for our `DataTableProductApplicationJoin`. May be used by Relay 1. */
   dataTableProductApplicationJoinEdge?: Maybe<DataTableProductApplicationJoinsEdge>;
 };
@@ -35287,44 +39087,144 @@ export type CreateDataTableProductApplicationJoinPayloadDataTableProductApplicat
   orderBy?: Maybe<Array<DataTableProductApplicationJoinsOrderBy>>;
 };
 
-/** All input for the create `DataTableProvince` mutation. */
-export type CreateDataTableProvinceInput = {
+/** All input for the create `DataTableProvisionalProduct` mutation. */
+export type CreateDataTableProvisionalProductInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableProvince` to be created by this mutation. */
-  dataTableProvince: DataTableProvinceInput;
+  /** The `DataTableProvisionalProduct` to be created by this mutation. */
+  dataTableProvisionalProduct: DataTableProvisionalProductInput;
 };
 
-/** An input for mutations affecting `DataTableProvince` */
-export type DataTableProvinceInput = {
+/** An input for mutations affecting `DataTableProvisionalProduct` */
+export type DataTableProvisionalProductInput = {
   id?: Maybe<Scalars['Int']>;
-  area?: Maybe<Scalars['String']>;
-  nome?: Maybe<Scalars['String']>;
-  codigo?: Maybe<Scalars['String']>;
-  capital?: Maybe<Scalars['String']>;
-  comunas?: Maybe<Scalars['String']>;
-  populacao?: Maybe<Scalars['String']>;
-  municipios?: Maybe<Scalars['String']>;
-  nameUppercase?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  isActive?: Maybe<Scalars['Boolean']>;
+  productId?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  originalId?: Maybe<Scalars['String']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  registeredIn?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  applicantId?: Maybe<Scalars['Int']>;
+  companyName?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  medicalProductClassification?: Maybe<Scalars['String']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  atcCode?: Maybe<Scalars['JSON']>;
+  pharmacopeia?: Maybe<Scalars['String']>;
+  gmpCertificate?: Maybe<Scalars['JSON']>;
+  prodRegCertificate?: Maybe<Scalars['JSON']>;
+  prequalified?: Maybe<Scalars['Boolean']>;
+  manufacturerPrequalified?: Maybe<Scalars['JSON']>;
+  loaSource?: Maybe<Scalars['String']>;
+  letterOfAuthorisation?: Maybe<Scalars['JSON']>;
+  packagingSizesForm?: Maybe<Scalars['JSON']>;
+  packagingSizesFilterData?: Maybe<Scalars['String']>;
+  manufacturersFilterData?: Maybe<Scalars['String']>;
+  activeIngredientsFilterData?: Maybe<Scalars['String']>;
+  dataTableProvisionalProductApplicationJoinsUsingId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInverseInput>;
 };
 
-/** The output of our create `DataTableProvince` mutation. */
-export type CreateDataTableProvincePayload = {
-  __typename?: 'CreateDataTableProvincePayload';
+/** The output of our create `DataTableProvisionalProduct` mutation. */
+export type CreateDataTableProvisionalProductPayload = {
+  __typename?: 'CreateDataTableProvisionalProductPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableProvince` that was created by this mutation. */
-  dataTableProvince?: Maybe<DataTableProvince>;
+  /** The `DataTableProvisionalProduct` that was created by this mutation. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableProvince`. May be used by Relay 1. */
-  dataTableProvinceEdge?: Maybe<DataTableProvincesEdge>;
+  /** An edge for our `DataTableProvisionalProduct`. May be used by Relay 1. */
+  dataTableProvisionalProductEdge?: Maybe<DataTableProvisionalProductsEdge>;
 };
 
 
-/** The output of our create `DataTableProvince` mutation. */
-export type CreateDataTableProvincePayloadDataTableProvinceEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableProvincesOrderBy>>;
+/** The output of our create `DataTableProvisionalProduct` mutation. */
+export type CreateDataTableProvisionalProductPayloadDataTableProvisionalProductEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductsOrderBy>>;
+};
+
+/** All input for the create `DataTableProvisionalProductApplicationJoin` mutation. */
+export type CreateDataTableProvisionalProductApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableProvisionalProductApplicationJoin` to be created by this mutation. */
+  dataTableProvisionalProductApplicationJoin: DataTableProvisionalProductApplicationJoinInput;
+};
+
+/** An input for mutations affecting `DataTableProvisionalProductApplicationJoin` */
+export type DataTableProvisionalProductApplicationJoinInput = {
+  id?: Maybe<Scalars['Int']>;
+  applicationId?: Maybe<Scalars['Int']>;
+  dataTableProvisionalProductId?: Maybe<Scalars['Int']>;
+  applicationToApplicationId?: Maybe<DataTableProvisionalProductApplicationApplicationIdFkeyInput>;
+  dataTableProvisionalProductToDataTableProvisionalProductId?: Maybe<DataTableProvisionalProducDataTableProvisionalProduFkeyInput>;
+};
+
+/** The output of our create `DataTableProvisionalProductApplicationJoin` mutation. */
+export type CreateDataTableProvisionalProductApplicationJoinPayload = {
+  __typename?: 'CreateDataTableProvisionalProductApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableProvisionalProductApplicationJoin` that was created by this mutation. */
+  dataTableProvisionalProductApplicationJoin?: Maybe<DataTableProvisionalProductApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableProvisionalProduct` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
+  /** An edge for our `DataTableProvisionalProductApplicationJoin`. May be used by Relay 1. */
+  dataTableProvisionalProductApplicationJoinEdge?: Maybe<DataTableProvisionalProductApplicationJoinsEdge>;
+};
+
+
+/** The output of our create `DataTableProvisionalProductApplicationJoin` mutation. */
+export type CreateDataTableProvisionalProductApplicationJoinPayloadDataTableProvisionalProductApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+};
+
+/** All input for the create `DataTableScheduledChemical` mutation. */
+export type CreateDataTableScheduledChemicalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableScheduledChemical` to be created by this mutation. */
+  dataTableScheduledChemical: DataTableScheduledChemicalInput;
+};
+
+/** An input for mutations affecting `DataTableScheduledChemical` */
+export type DataTableScheduledChemicalInput = {
+  id?: Maybe<Scalars['Int']>;
+  chemical?: Maybe<Scalars['String']>;
+  schedule?: Maybe<Scalars['String']>;
+};
+
+/** The output of our create `DataTableScheduledChemical` mutation. */
+export type CreateDataTableScheduledChemicalPayload = {
+  __typename?: 'CreateDataTableScheduledChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableScheduledChemical` that was created by this mutation. */
+  dataTableScheduledChemical?: Maybe<DataTableScheduledChemical>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableScheduledChemical`. May be used by Relay 1. */
+  dataTableScheduledChemicalEdge?: Maybe<DataTableScheduledChemicalsEdge>;
+};
+
+
+/** The output of our create `DataTableScheduledChemical` mutation. */
+export type CreateDataTableScheduledChemicalPayloadDataTableScheduledChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableScheduledChemicalsOrderBy>>;
 };
 
 /** All input for the create `DataTableStorageCondition` mutation. */
@@ -35338,8 +39238,9 @@ export type CreateDataTableStorageConditionInput = {
 /** An input for mutations affecting `DataTableStorageCondition` */
 export type DataTableStorageConditionInput = {
   id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our create `DataTableStorageCondition` mutation. */
@@ -35668,6 +39569,42 @@ export type CreateFilterPayloadFilterEdgeArgs = {
   orderBy?: Maybe<Array<FiltersOrderBy>>;
 };
 
+/** All input for the create `GrafanaDashboardImage` mutation. */
+export type CreateGrafanaDashboardImageInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrafanaDashboardImage` to be created by this mutation. */
+  grafanaDashboardImage: GrafanaDashboardImageInput;
+};
+
+/** An input for mutations affecting `GrafanaDashboardImage` */
+export type GrafanaDashboardImageInput = {
+  id?: Maybe<Scalars['Int']>;
+  name: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['String']>;
+  updatedDate?: Maybe<Scalars['Datetime']>;
+};
+
+/** The output of our create `GrafanaDashboardImage` mutation. */
+export type CreateGrafanaDashboardImagePayload = {
+  __typename?: 'CreateGrafanaDashboardImagePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrafanaDashboardImage` that was created by this mutation. */
+  grafanaDashboardImage?: Maybe<GrafanaDashboardImage>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `GrafanaDashboardImage`. May be used by Relay 1. */
+  grafanaDashboardImageEdge?: Maybe<GrafanaDashboardImagesEdge>;
+};
+
+
+/** The output of our create `GrafanaDashboardImage` mutation. */
+export type CreateGrafanaDashboardImagePayloadGrafanaDashboardImageEdgeArgs = {
+  orderBy?: Maybe<Array<GrafanaDashboardImagesOrderBy>>;
+};
+
 /** All input for the create `Notification` mutation. */
 export type CreateNotificationInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -35737,19 +39674,22 @@ export type OrganisationInput = {
   logoUrl?: Maybe<Scalars['String']>;
   isSystemOrg?: Maybe<Scalars['Boolean']>;
   registrationDocumentation?: Maybe<Scalars['JSON']>;
-  agent?: Maybe<Scalars['JSON']>;
-  contact?: Maybe<Scalars['JSON']>;
-  authorisation?: Maybe<Scalars['JSON']>;
   country?: Maybe<Scalars['String']>;
   province?: Maybe<Scalars['String']>;
+  contactEmail?: Maybe<Scalars['String']>;
+  contactPhone?: Maybe<Scalars['String']>;
   postalAddress?: Maybe<Scalars['String']>;
-  postalCountry?: Maybe<Scalars['String']>;
-  postalProvince?: Maybe<Scalars['String']>;
-  isActive?: Maybe<Scalars['Boolean']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  agentId?: Maybe<Scalars['Int']>;
-  type?: Maybe<Scalars['String']>;
-  nifNumber?: Maybe<Scalars['String']>;
+  localAgentName?: Maybe<Scalars['String']>;
+  localAgentEmail?: Maybe<Scalars['String']>;
+  localAgentPhoneNumber?: Maybe<Scalars['String']>;
+  localAgentBusinessAddress?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['JSON']>;
+  businessCertificate?: Maybe<Scalars['JSON']>;
+  tinLetter?: Maybe<Scalars['JSON']>;
+  subType?: Maybe<Scalars['String']>;
+  otherDocuments?: Maybe<Scalars['JSON']>;
+  isSponsorCompany?: Maybe<Scalars['Boolean']>;
+  isChemicalImporter?: Maybe<Scalars['Boolean']>;
   applicationsUsingId?: Maybe<ApplicationOrgIdFkeyInverseInput>;
   reviewAssignmentsUsingId?: Maybe<ReviewAssignmentOrganisationIdFkeyInverseInput>;
   applicationNotesUsingId?: Maybe<ApplicationNoteOrgIdFkeyInverseInput>;
@@ -35942,43 +39882,6 @@ export type CreatePermissionPolicyPayload = {
 /** The output of our create `PermissionPolicy` mutation. */
 export type CreatePermissionPolicyPayloadPermissionPolicyEdgeArgs = {
   orderBy?: Maybe<Array<PermissionPoliciesOrderBy>>;
-};
-
-/** All input for the create `ProductApplicationJoin` mutation. */
-export type CreateProductApplicationJoinInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `ProductApplicationJoin` to be created by this mutation. */
-  productApplicationJoin: ProductApplicationJoinInput;
-};
-
-/** An input for mutations affecting `ProductApplicationJoin` */
-export type ProductApplicationJoinInput = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  productId: Scalars['Int'];
-  applicationToApplicationId?: Maybe<ProductApplicationJoinApplicationIdFkeyInput>;
-};
-
-/** The output of our create `ProductApplicationJoin` mutation. */
-export type CreateProductApplicationJoinPayload = {
-  __typename?: 'CreateProductApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `ProductApplicationJoin` that was created by this mutation. */
-  productApplicationJoin?: Maybe<ProductApplicationJoin>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `ProductApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** An edge for our `ProductApplicationJoin`. May be used by Relay 1. */
-  productApplicationJoinEdge?: Maybe<ProductApplicationJoinsEdge>;
-};
-
-
-/** The output of our create `ProductApplicationJoin` mutation. */
-export type CreateProductApplicationJoinPayloadProductApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<ProductApplicationJoinsOrderBy>>;
 };
 
 /** All input for the create `Review` mutation. */
@@ -36251,6 +40154,7 @@ export type ReviewResponseInput = {
   templateElementId?: Maybe<Scalars['Int']>;
   recommendedApplicantVisibility?: Maybe<ReviewResponseRecommendedApplicantVisibility>;
   status?: Maybe<ReviewResponseStatus>;
+  isLatestReviewSubmission?: Maybe<Scalars['Boolean']>;
   stageNumber?: Maybe<Scalars['Int']>;
   applicationResponseToApplicationResponseId?: Maybe<ReviewResponseApplicationResponseIdFkeyInput>;
   reviewResponseToReviewResponseLinkId?: Maybe<ReviewResponseReviewResponseLinkIdFkeyInput>;
@@ -36886,11 +40790,6 @@ export type UserInput = {
   phone?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   country?: Maybe<Scalars['String']>;
-  province?: Maybe<Scalars['String']>;
-  registrationDate?: Maybe<Scalars['Datetime']>;
-  nationalId?: Maybe<Scalars['String']>;
-  foreignId?: Maybe<Scalars['JSON']>;
-  foreignIdType?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
   applicationsUsingId?: Maybe<ApplicationUserIdFkeyInverseInput>;
   reviewAssignmentsToAssignerIdUsingId?: Maybe<ReviewAssignmentAssignerIdFkeyInverseInput>;
@@ -36906,6 +40805,7 @@ export type UserInput = {
   triggerSchedulesUsingId?: Maybe<TriggerScheduleEditorUserIdFkeyInverseInput>;
   userApplicationJoinsUsingId?: Maybe<UserApplicationJoinUserIdFkeyInverseInput>;
   userOrganisationsUsingId?: Maybe<UserOrganisationUserIdFkeyInverseInput>;
+  applicationReviewerActionsUsingId?: Maybe<ApplicationReviewerActionUserIdFkeyInverseInput>;
 };
 
 /** The output of our create `User` mutation. */
@@ -36983,7 +40883,6 @@ export type UserOrganisationInput = {
   userRole?: Maybe<Scalars['String']>;
   userToUserId?: Maybe<UserOrganisationUserIdFkeyInput>;
   organisationToOrganisationId?: Maybe<UserOrganisationOrganisationIdFkeyInput>;
-  userOrganisationApplicationJoinsUsingId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInverseInput>;
 };
 
 /** The output of our create `UserOrganisation` mutation. */
@@ -37007,46 +40906,6 @@ export type CreateUserOrganisationPayload = {
 /** The output of our create `UserOrganisation` mutation. */
 export type CreateUserOrganisationPayloadUserOrganisationEdgeArgs = {
   orderBy?: Maybe<Array<UserOrganisationsOrderBy>>;
-};
-
-/** All input for the create `UserOrganisationApplicationJoin` mutation. */
-export type CreateUserOrganisationApplicationJoinInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `UserOrganisationApplicationJoin` to be created by this mutation. */
-  userOrganisationApplicationJoin: UserOrganisationApplicationJoinInput;
-};
-
-/** An input for mutations affecting `UserOrganisationApplicationJoin` */
-export type UserOrganisationApplicationJoinInput = {
-  id?: Maybe<Scalars['Int']>;
-  applicationId?: Maybe<Scalars['Int']>;
-  userOrganisationId?: Maybe<Scalars['Int']>;
-  applicationToApplicationId?: Maybe<UserOrganisationApplicationJoinApplicationIdFkeyInput>;
-  userOrganisationToUserOrganisationId?: Maybe<UserOrganisationApplicationJoinUserOrganisationIdFkeyInput>;
-};
-
-/** The output of our create `UserOrganisationApplicationJoin` mutation. */
-export type CreateUserOrganisationApplicationJoinPayload = {
-  __typename?: 'CreateUserOrganisationApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `UserOrganisationApplicationJoin` that was created by this mutation. */
-  userOrganisationApplicationJoin?: Maybe<UserOrganisationApplicationJoin>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `UserOrganisationApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** Reads a single `UserOrganisation` that is related to this `UserOrganisationApplicationJoin`. */
-  userOrganisation?: Maybe<UserOrganisation>;
-  /** An edge for our `UserOrganisationApplicationJoin`. May be used by Relay 1. */
-  userOrganisationApplicationJoinEdge?: Maybe<UserOrganisationApplicationJoinsEdge>;
-};
-
-
-/** The output of our create `UserOrganisationApplicationJoin` mutation. */
-export type CreateUserOrganisationApplicationJoinPayloadUserOrganisationApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
 };
 
 /** All input for the create `Verification` mutation. */
@@ -37384,6 +41243,58 @@ export type UpdateApplicationResponseInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `updateApplicationReviewerActionByNodeId` mutation. */
+export type UpdateApplicationReviewerActionByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `ApplicationReviewerAction` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `ApplicationReviewerAction` being updated. */
+  patch: ApplicationReviewerActionPatch;
+};
+
+/** The output of our update `ApplicationReviewerAction` mutation. */
+export type UpdateApplicationReviewerActionPayload = {
+  __typename?: 'UpdateApplicationReviewerActionPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `ApplicationReviewerAction` that was updated by this mutation. */
+  applicationReviewerAction?: Maybe<ApplicationReviewerAction>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `User` that is related to this `ApplicationReviewerAction`. */
+  user?: Maybe<User>;
+  /** Reads a single `Application` that is related to this `ApplicationReviewerAction`. */
+  application?: Maybe<Application>;
+  /** An edge for our `ApplicationReviewerAction`. May be used by Relay 1. */
+  applicationReviewerActionEdge?: Maybe<ApplicationReviewerActionsEdge>;
+};
+
+
+/** The output of our update `ApplicationReviewerAction` mutation. */
+export type UpdateApplicationReviewerActionPayloadApplicationReviewerActionEdgeArgs = {
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
+};
+
+/** All input for the `updateApplicationReviewerAction` mutation. */
+export type UpdateApplicationReviewerActionInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `ApplicationReviewerAction` being updated. */
+  patch: ApplicationReviewerActionPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateApplicationReviewerActionByUserIdAndApplicationId` mutation. */
+export type UpdateApplicationReviewerActionByUserIdAndApplicationIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `ApplicationReviewerAction` being updated. */
+  patch: ApplicationReviewerActionPatch;
+  userId: Scalars['Int'];
+  applicationId: Scalars['Int'];
+};
+
 /** All input for the `updateApplicationStageHistoryByNodeId` mutation. */
 export type UpdateApplicationStageHistoryByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -37623,52 +41534,6 @@ export type UpdateDataTableByTableNameInput = {
   tableName: Scalars['String'];
 };
 
-/** All input for the `updateDataTableManufacturingStepByNodeId` mutation. */
-export type UpdateDataTableManufacturingStepByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableManufacturingStep` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableManufacturingStep` being updated. */
-  patch: DataTableManufacturingStepPatch;
-};
-
-/** Represents an update to a `DataTableManufacturingStep`. Fields that are set will be updated. */
-export type DataTableManufacturingStepPatch = {
-  id?: Maybe<Scalars['Int']>;
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
-  definition?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableManufacturingStep` mutation. */
-export type UpdateDataTableManufacturingStepPayload = {
-  __typename?: 'UpdateDataTableManufacturingStepPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStep` that was updated by this mutation. */
-  dataTableManufacturingStep?: Maybe<DataTableManufacturingStep>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStep`. May be used by Relay 1. */
-  dataTableManufacturingStepEdge?: Maybe<DataTableManufacturingStepsEdge>;
-};
-
-
-/** The output of our update `DataTableManufacturingStep` mutation. */
-export type UpdateDataTableManufacturingStepPayloadDataTableManufacturingStepEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsOrderBy>>;
-};
-
-/** All input for the `updateDataTableManufacturingStep` mutation. */
-export type UpdateDataTableManufacturingStepInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableManufacturingStep` being updated. */
-  patch: DataTableManufacturingStepPatch;
-  id: Scalars['Int'];
-};
-
 /** All input for the `updateDataTableActiveIngredientByNodeId` mutation. */
 export type UpdateDataTableActiveIngredientByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -37684,7 +41549,6 @@ export type DataTableActiveIngredientPatch = {
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   latina?: Maybe<Scalars['String']>;
-  portuguese?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableActiveIngredient` mutation. */
@@ -37729,7 +41593,8 @@ export type UpdateDataTableAdministrationRouteByNodeIdInput = {
 export type DataTableAdministrationRoutePatch = {
   id?: Maybe<Scalars['Int']>;
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableAdministrationRoute` mutation. */
@@ -37773,7 +41638,7 @@ export type UpdateDataTableAnnexByNodeIdInput = {
 /** Represents an update to a `DataTableAnnex`. Fields that are set will be updated. */
 export type DataTableAnnexPatch = {
   id?: Maybe<Scalars['Int']>;
-  country?: Maybe<Scalars['String']>;
+  nameCommon?: Maybe<Scalars['String']>;
   source?: Maybe<Scalars['String']>;
 };
 
@@ -37897,53 +41762,6 @@ export type UpdateDataTableAtcCodeInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `updateDataTableAtcTherapeuticCategoryByNodeId` mutation. */
-export type UpdateDataTableAtcTherapeuticCategoryByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableAtcTherapeuticCategory` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableAtcTherapeuticCategory` being updated. */
-  patch: DataTableAtcTherapeuticCategoryPatch;
-};
-
-/** Represents an update to a `DataTableAtcTherapeuticCategory`. Fields that are set will be updated. */
-export type DataTableAtcTherapeuticCategoryPatch = {
-  id?: Maybe<Scalars['Int']>;
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableAtcTherapeuticCategory` mutation. */
-export type UpdateDataTableAtcTherapeuticCategoryPayload = {
-  __typename?: 'UpdateDataTableAtcTherapeuticCategoryPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableAtcTherapeuticCategory` that was updated by this mutation. */
-  dataTableAtcTherapeuticCategory?: Maybe<DataTableAtcTherapeuticCategory>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableAtcTherapeuticCategory`. May be used by Relay 1. */
-  dataTableAtcTherapeuticCategoryEdge?: Maybe<DataTableAtcTherapeuticCategoriesEdge>;
-};
-
-
-/** The output of our update `DataTableAtcTherapeuticCategory` mutation. */
-export type UpdateDataTableAtcTherapeuticCategoryPayloadDataTableAtcTherapeuticCategoryEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableAtcTherapeuticCategoriesOrderBy>>;
-};
-
-/** All input for the `updateDataTableAtcTherapeuticCategory` mutation. */
-export type UpdateDataTableAtcTherapeuticCategoryInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableAtcTherapeuticCategory` being updated. */
-  patch: DataTableAtcTherapeuticCategoryPatch;
-  id: Scalars['Int'];
-};
-
 /** All input for the `updateDataTableContainerByNodeId` mutation. */
 export type UpdateDataTableContainerByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -37958,7 +41776,8 @@ export type UpdateDataTableContainerByNodeIdInput = {
 export type DataTableContainerPatch = {
   id?: Maybe<Scalars['Int']>;
   code?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableContainer` mutation. */
@@ -38006,7 +41825,6 @@ export type DataTableCountryPatch = {
   nameOfficial?: Maybe<Scalars['String']>;
   translationsPorOfficial?: Maybe<Scalars['String']>;
   translationsPorCommon?: Maybe<Scalars['String']>;
-  translationCommonNoAccent?: Maybe<Scalars['String']>;
   flag?: Maybe<Scalars['String']>;
 };
 
@@ -38051,7 +41869,9 @@ export type UpdateDataTableDosageFormByNodeIdInput = {
 /** Represents an update to a `DataTableDosageForm`. Fields that are set will be updated. */
 export type DataTableDosageFormPatch = {
   id?: Maybe<Scalars['Int']>;
-  dosageForm?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableDosageForm` mutation. */
@@ -38079,6 +41899,50 @@ export type UpdateDataTableDosageFormInput = {
   clientMutationId?: Maybe<Scalars['String']>;
   /** An object where the defined keys will be set on the `DataTableDosageForm` being updated. */
   patch: DataTableDosageFormPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableDosageFormGroupByNodeId` mutation. */
+export type UpdateDataTableDosageFormGroupByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableDosageFormGroup` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableDosageFormGroup` being updated. */
+  patch: DataTableDosageFormGroupPatch;
+};
+
+/** Represents an update to a `DataTableDosageFormGroup`. Fields that are set will be updated. */
+export type DataTableDosageFormGroupPatch = {
+  id?: Maybe<Scalars['Int']>;
+  dosageFormGroups?: Maybe<Scalars['String']>;
+};
+
+/** The output of our update `DataTableDosageFormGroup` mutation. */
+export type UpdateDataTableDosageFormGroupPayload = {
+  __typename?: 'UpdateDataTableDosageFormGroupPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableDosageFormGroup` that was updated by this mutation. */
+  dataTableDosageFormGroup?: Maybe<DataTableDosageFormGroup>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableDosageFormGroup`. May be used by Relay 1. */
+  dataTableDosageFormGroupEdge?: Maybe<DataTableDosageFormGroupsEdge>;
+};
+
+
+/** The output of our update `DataTableDosageFormGroup` mutation. */
+export type UpdateDataTableDosageFormGroupPayloadDataTableDosageFormGroupEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableDosageFormGroupsOrderBy>>;
+};
+
+/** All input for the `updateDataTableDosageFormGroup` mutation. */
+export type UpdateDataTableDosageFormGroupInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableDosageFormGroup` being updated. */
+  patch: DataTableDosageFormGroupPatch;
   id: Scalars['Int'];
 };
 
@@ -38131,99 +41995,6 @@ export type UpdateDataTableGenericIngredientInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `updateDataTableIngredientsListByNodeId` mutation. */
-export type UpdateDataTableIngredientsListByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableIngredientsList` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableIngredientsList` being updated. */
-  patch: DataTableIngredientsListPatch;
-};
-
-/** Represents an update to a `DataTableIngredientsList`. Fields that are set will be updated. */
-export type DataTableIngredientsListPatch = {
-  id?: Maybe<Scalars['Int']>;
-  whoAtcId?: Maybe<Scalars['String']>;
-  atcCode?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  category?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableIngredientsList` mutation. */
-export type UpdateDataTableIngredientsListPayload = {
-  __typename?: 'UpdateDataTableIngredientsListPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableIngredientsList` that was updated by this mutation. */
-  dataTableIngredientsList?: Maybe<DataTableIngredientsList>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableIngredientsList`. May be used by Relay 1. */
-  dataTableIngredientsListEdge?: Maybe<DataTableIngredientsListsEdge>;
-};
-
-
-/** The output of our update `DataTableIngredientsList` mutation. */
-export type UpdateDataTableIngredientsListPayloadDataTableIngredientsListEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableIngredientsListsOrderBy>>;
-};
-
-/** All input for the `updateDataTableIngredientsList` mutation. */
-export type UpdateDataTableIngredientsListInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableIngredientsList` being updated. */
-  patch: DataTableIngredientsListPatch;
-  id: Scalars['Int'];
-};
-
-/** All input for the `updateDataTableInternationalDiallingPrefixByNodeId` mutation. */
-export type UpdateDataTableInternationalDiallingPrefixByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableInternationalDiallingPrefix` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableInternationalDiallingPrefix` being updated. */
-  patch: DataTableInternationalDiallingPrefixPatch;
-};
-
-/** Represents an update to a `DataTableInternationalDiallingPrefix`. Fields that are set will be updated. */
-export type DataTableInternationalDiallingPrefixPatch = {
-  id?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
-  country?: Maybe<Scalars['String']>;
-  display?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableInternationalDiallingPrefix` mutation. */
-export type UpdateDataTableInternationalDiallingPrefixPayload = {
-  __typename?: 'UpdateDataTableInternationalDiallingPrefixPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableInternationalDiallingPrefix` that was updated by this mutation. */
-  dataTableInternationalDiallingPrefix?: Maybe<DataTableInternationalDiallingPrefix>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableInternationalDiallingPrefix`. May be used by Relay 1. */
-  dataTableInternationalDiallingPrefixEdge?: Maybe<DataTableInternationalDiallingPrefixesEdge>;
-};
-
-
-/** The output of our update `DataTableInternationalDiallingPrefix` mutation. */
-export type UpdateDataTableInternationalDiallingPrefixPayloadDataTableInternationalDiallingPrefixEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableInternationalDiallingPrefixesOrderBy>>;
-};
-
-/** All input for the `updateDataTableInternationalDiallingPrefix` mutation. */
-export type UpdateDataTableInternationalDiallingPrefixInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableInternationalDiallingPrefix` being updated. */
-  patch: DataTableInternationalDiallingPrefixPatch;
-  id: Scalars['Int'];
-};
-
 /** All input for the `updateDataTableListOfSraByNodeId` mutation. */
 export type UpdateDataTableListOfSraByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -38268,48 +42039,388 @@ export type UpdateDataTableListOfSraInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `updateDataTableManufacturingStepsSimplerByNodeId` mutation. */
-export type UpdateDataTableManufacturingStepsSimplerByNodeIdInput = {
+/** All input for the `updateDataTableManufacturerByNodeId` mutation. */
+export type UpdateDataTableManufacturerByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableManufacturingStepsSimpler` to be updated. */
+  /** The globally unique `ID` which will identify a single `DataTableManufacturer` to be updated. */
   nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableManufacturingStepsSimpler` being updated. */
-  patch: DataTableManufacturingStepsSimplerPatch;
+  /** An object where the defined keys will be set on the `DataTableManufacturer` being updated. */
+  patch: DataTableManufacturerPatch;
 };
 
-/** Represents an update to a `DataTableManufacturingStepsSimpler`. Fields that are set will be updated. */
-export type DataTableManufacturingStepsSimplerPatch = {
-  id?: Maybe<Scalars['Int']>;
-  tipoDeFabricante?: Maybe<Scalars['String']>;
-  manufacturingOperation?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableManufacturingStepsSimpler` mutation. */
-export type UpdateDataTableManufacturingStepsSimplerPayload = {
-  __typename?: 'UpdateDataTableManufacturingStepsSimplerPayload';
+/** The output of our update `DataTableManufacturer` mutation. */
+export type UpdateDataTableManufacturerPayload = {
+  __typename?: 'UpdateDataTableManufacturerPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStepsSimpler` that was updated by this mutation. */
-  dataTableManufacturingStepsSimpler?: Maybe<DataTableManufacturingStepsSimpler>;
+  /** The `DataTableManufacturer` that was updated by this mutation. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStepsSimpler`. May be used by Relay 1. */
-  dataTableManufacturingStepsSimplerEdge?: Maybe<DataTableManufacturingStepsSimplersEdge>;
+  /** An edge for our `DataTableManufacturer`. May be used by Relay 1. */
+  dataTableManufacturerEdge?: Maybe<DataTableManufacturersEdge>;
 };
 
 
-/** The output of our update `DataTableManufacturingStepsSimpler` mutation. */
-export type UpdateDataTableManufacturingStepsSimplerPayloadDataTableManufacturingStepsSimplerEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsSimplersOrderBy>>;
+/** The output of our update `DataTableManufacturer` mutation. */
+export type UpdateDataTableManufacturerPayloadDataTableManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturersOrderBy>>;
 };
 
-/** All input for the `updateDataTableManufacturingStepsSimpler` mutation. */
-export type UpdateDataTableManufacturingStepsSimplerInput = {
+/** All input for the `updateDataTableManufacturer` mutation. */
+export type UpdateDataTableManufacturerInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableManufacturingStepsSimpler` being updated. */
-  patch: DataTableManufacturingStepsSimplerPatch;
+  /** An object where the defined keys will be set on the `DataTableManufacturer` being updated. */
+  patch: DataTableManufacturerPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableManufacturerApplicationJoinByNodeId` mutation. */
+export type UpdateDataTableManufacturerApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerApplicationJoin` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableManufacturerApplicationJoin` being updated. */
+  patch: DataTableManufacturerApplicationJoinPatch;
+};
+
+/** The output of our update `DataTableManufacturerApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerApplicationJoinPayload = {
+  __typename?: 'UpdateDataTableManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerApplicationJoin` that was updated by this mutation. */
+  dataTableManufacturerApplicationJoin?: Maybe<DataTableManufacturerApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturer` that is related to this `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+  /** An edge for our `DataTableManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerApplicationJoinEdge?: Maybe<DataTableManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our update `DataTableManufacturerApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerApplicationJoinPayloadDataTableManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `updateDataTableManufacturerApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableManufacturerApplicationJoin` being updated. */
+  patch: DataTableManufacturerApplicationJoinPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableManufacturerRepresentativeByNodeId` mutation. */
+export type UpdateDataTableManufacturerRepresentativeByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerRepresentative` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableManufacturerRepresentative` being updated. */
+  patch: DataTableManufacturerRepresentativePatch;
+};
+
+/** The output of our update `DataTableManufacturerRepresentative` mutation. */
+export type UpdateDataTableManufacturerRepresentativePayload = {
+  __typename?: 'UpdateDataTableManufacturerRepresentativePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentative` that was updated by this mutation. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableManufacturerRepresentative`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeEdge?: Maybe<DataTableManufacturerRepresentativesEdge>;
+};
+
+
+/** The output of our update `DataTableManufacturerRepresentative` mutation. */
+export type UpdateDataTableManufacturerRepresentativePayloadDataTableManufacturerRepresentativeEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativesOrderBy>>;
+};
+
+/** All input for the `updateDataTableManufacturerRepresentative` mutation. */
+export type UpdateDataTableManufacturerRepresentativeInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableManufacturerRepresentative` being updated. */
+  patch: DataTableManufacturerRepresentativePatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableManufacturerRepresentativeApplicationJoinByNodeId` mutation. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerRepresentativeApplicationJoin` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: DataTableManufacturerRepresentativeApplicationJoinPatch;
+};
+
+/** The output of our update `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinPayload = {
+  __typename?: 'UpdateDataTableManufacturerRepresentativeApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentativeApplicationJoin` that was updated by this mutation. */
+  dataTableManufacturerRepresentativeApplicationJoin?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturerRepresentative` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  /** An edge for our `DataTableManufacturerRepresentativeApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeApplicationJoinEdge?: Maybe<DataTableManufacturerRepresentativeApplicationJoinsEdge>;
+};
+
+
+/** The output of our update `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinPayloadDataTableManufacturerRepresentativeApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `updateDataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type UpdateDataTableManufacturerRepresentativeApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableManufacturerRepresentativeApplicationJoin` being updated. */
+  patch: DataTableManufacturerRepresentativeApplicationJoinPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTablePermitChemicalByNodeId` mutation. */
+export type UpdateDataTablePermitChemicalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePermitChemical` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTablePermitChemical` being updated. */
+  patch: DataTablePermitChemicalPatch;
+};
+
+/** The output of our update `DataTablePermitChemical` mutation. */
+export type UpdateDataTablePermitChemicalPayload = {
+  __typename?: 'UpdateDataTablePermitChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemical` that was updated by this mutation. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePermitChemical`. May be used by Relay 1. */
+  dataTablePermitChemicalEdge?: Maybe<DataTablePermitChemicalsEdge>;
+};
+
+
+/** The output of our update `DataTablePermitChemical` mutation. */
+export type UpdateDataTablePermitChemicalPayloadDataTablePermitChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalsOrderBy>>;
+};
+
+/** All input for the `updateDataTablePermitChemical` mutation. */
+export type UpdateDataTablePermitChemicalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTablePermitChemical` being updated. */
+  patch: DataTablePermitChemicalPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTablePermitChemicalApplicationJoinByNodeId` mutation. */
+export type UpdateDataTablePermitChemicalApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePermitChemicalApplicationJoin` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTablePermitChemicalApplicationJoin` being updated. */
+  patch: DataTablePermitChemicalApplicationJoinPatch;
+};
+
+/** The output of our update `DataTablePermitChemicalApplicationJoin` mutation. */
+export type UpdateDataTablePermitChemicalApplicationJoinPayload = {
+  __typename?: 'UpdateDataTablePermitChemicalApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemicalApplicationJoin` that was updated by this mutation. */
+  dataTablePermitChemicalApplicationJoin?: Maybe<DataTablePermitChemicalApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePermitChemical` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  /** An edge for our `DataTablePermitChemicalApplicationJoin`. May be used by Relay 1. */
+  dataTablePermitChemicalApplicationJoinEdge?: Maybe<DataTablePermitChemicalApplicationJoinsEdge>;
+};
+
+
+/** The output of our update `DataTablePermitChemicalApplicationJoin` mutation. */
+export type UpdateDataTablePermitChemicalApplicationJoinPayloadDataTablePermitChemicalApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `updateDataTablePermitChemicalApplicationJoin` mutation. */
+export type UpdateDataTablePermitChemicalApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTablePermitChemicalApplicationJoin` being updated. */
+  patch: DataTablePermitChemicalApplicationJoinPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTablePreRegisteredProductsProvisionalByNodeId` mutation. */
+export type UpdateDataTablePreRegisteredProductsProvisionalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePreRegisteredProductsProvisional` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTablePreRegisteredProductsProvisional` being updated. */
+  patch: DataTablePreRegisteredProductsProvisionalPatch;
+};
+
+/** Represents an update to a `DataTablePreRegisteredProductsProvisional`. Fields that are set will be updated. */
+export type DataTablePreRegisteredProductsProvisionalPatch = {
+  id?: Maybe<Scalars['Int']>;
+  productIdOriginal?: Maybe<Scalars['String']>;
+  productIdUnique?: Maybe<Scalars['String']>;
+  authority?: Maybe<Scalars['String']>;
+  tradeName?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  sponsorName?: Maybe<Scalars['String']>;
+  activeIngredients?: Maybe<Scalars['JSON']>;
+  activeIngredientsResponse?: Maybe<Scalars['JSON']>;
+  multipleFormulations?: Maybe<Scalars['Boolean']>;
+  componentsOriginal?: Maybe<Scalars['JSON']>;
+  packSizes?: Maybe<Scalars['JSON']>;
+  packSizesResponse?: Maybe<Scalars['JSON']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  storageConditions?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  indications?: Maybe<Scalars['String']>;
+  productType?: Maybe<Scalars['String']>;
+  containerType?: Maybe<Scalars['String']>;
+  effectiveDate?: Maybe<Scalars['Date']>;
+  manufacturers?: Maybe<Scalars['JSON']>;
+  manufacturersResponse?: Maybe<Scalars['JSON']>;
+};
+
+/** The output of our update `DataTablePreRegisteredProductsProvisional` mutation. */
+export type UpdateDataTablePreRegisteredProductsProvisionalPayload = {
+  __typename?: 'UpdateDataTablePreRegisteredProductsProvisionalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePreRegisteredProductsProvisional` that was updated by this mutation. */
+  dataTablePreRegisteredProductsProvisional?: Maybe<DataTablePreRegisteredProductsProvisional>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePreRegisteredProductsProvisional`. May be used by Relay 1. */
+  dataTablePreRegisteredProductsProvisionalEdge?: Maybe<DataTablePreRegisteredProductsProvisionalsEdge>;
+};
+
+
+/** The output of our update `DataTablePreRegisteredProductsProvisional` mutation. */
+export type UpdateDataTablePreRegisteredProductsProvisionalPayloadDataTablePreRegisteredProductsProvisionalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePreRegisteredProductsProvisionalsOrderBy>>;
+};
+
+/** All input for the `updateDataTablePreRegisteredProductsProvisional` mutation. */
+export type UpdateDataTablePreRegisteredProductsProvisionalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTablePreRegisteredProductsProvisional` being updated. */
+  patch: DataTablePreRegisteredProductsProvisionalPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTablePrequalManufacturerByNodeId` mutation. */
+export type UpdateDataTablePrequalManufacturerByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePrequalManufacturer` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTablePrequalManufacturer` being updated. */
+  patch: DataTablePrequalManufacturerPatch;
+};
+
+/** The output of our update `DataTablePrequalManufacturer` mutation. */
+export type UpdateDataTablePrequalManufacturerPayload = {
+  __typename?: 'UpdateDataTablePrequalManufacturerPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturer` that was updated by this mutation. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePrequalManufacturer`. May be used by Relay 1. */
+  dataTablePrequalManufacturerEdge?: Maybe<DataTablePrequalManufacturersEdge>;
+};
+
+
+/** The output of our update `DataTablePrequalManufacturer` mutation. */
+export type UpdateDataTablePrequalManufacturerPayloadDataTablePrequalManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturersOrderBy>>;
+};
+
+/** All input for the `updateDataTablePrequalManufacturer` mutation. */
+export type UpdateDataTablePrequalManufacturerInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTablePrequalManufacturer` being updated. */
+  patch: DataTablePrequalManufacturerPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTablePrequalManufacturerApplicationJoinByNodeId` mutation. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePrequalManufacturerApplicationJoin` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: DataTablePrequalManufacturerApplicationJoinPatch;
+};
+
+/** The output of our update `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinPayload = {
+  __typename?: 'UpdateDataTablePrequalManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturerApplicationJoin` that was updated by this mutation. */
+  dataTablePrequalManufacturerApplicationJoin?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePrequalManufacturer` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  /** An edge for our `DataTablePrequalManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTablePrequalManufacturerApplicationJoinEdge?: Maybe<DataTablePrequalManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our update `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinPayloadDataTablePrequalManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `updateDataTablePrequalManufacturerApplicationJoin` mutation. */
+export type UpdateDataTablePrequalManufacturerApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTablePrequalManufacturerApplicationJoin` being updated. */
+  patch: DataTablePrequalManufacturerApplicationJoinPatch;
   id: Scalars['Int'];
 };
 
@@ -38326,8 +42437,7 @@ export type UpdateDataTableProcessingStepByNodeIdInput = {
 /** Represents an update to a `DataTableProcessingStep`. Fields that are set will be updated. */
 export type DataTableProcessingStepPatch = {
   id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  processingStep?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableProcessingStep` mutation. */
@@ -38366,6 +42476,40 @@ export type UpdateDataTableProductByNodeIdInput = {
   nodeId: Scalars['ID'];
   /** An object where the defined keys will be set on the `DataTableProduct` being updated. */
   patch: DataTableProductPatch;
+};
+
+/** Represents an update to a `DataTableProduct`. Fields that are set will be updated. */
+export type DataTableProductPatch = {
+  id?: Maybe<Scalars['Int']>;
+  expiryDate?: Maybe<Scalars['Datetime']>;
+  productOrigin?: Maybe<Scalars['String']>;
+  registrationDate?: Maybe<Scalars['Datetime']>;
+  registrationSerial?: Maybe<Scalars['String']>;
+  sra?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  atcCode?: Maybe<Scalars['String']>;
+  shelfLife?: Maybe<Scalars['String']>;
+  dosageForm?: Maybe<Scalars['String']>;
+  atcCategory?: Maybe<Scalars['String']>;
+  companyName?: Maybe<Scalars['String']>;
+  formulations?: Maybe<Scalars['String']>;
+  companyPhone?: Maybe<Scalars['String']>;
+  companyAddress?: Maybe<Scalars['String']>;
+  packagingSizes?: Maybe<Scalars['JSON']>;
+  importerAddress?: Maybe<Scalars['String']>;
+  activeSubstances?: Maybe<Scalars['JSON']>;
+  primaryContainer?: Maybe<Scalars['String']>;
+  administrationUnit?: Maybe<Scalars['String']>;
+  storageTemperature?: Maybe<Scalars['String']>;
+  proposedIndications?: Maybe<Scalars['String']>;
+  componentFormulation?: Maybe<Scalars['String']>;
+  packagingDescription?: Maybe<Scalars['String']>;
+  dosageFormDescription?: Maybe<Scalars['String']>;
+  routeOfAdministration?: Maybe<Scalars['String']>;
+  finishedProductManufacturers?: Maybe<Scalars['String']>;
+  nationalMedicalClassification?: Maybe<Scalars['String']>;
+  activeIngredientsManufacturers?: Maybe<Scalars['String']>;
+  companyId?: Maybe<Scalars['Int']>;
 };
 
 /** The output of our update `DataTableProduct` mutation. */
@@ -38417,8 +42561,6 @@ export type UpdateDataTableProductApplicationJoinPayload = {
   query?: Maybe<Query>;
   /** Reads a single `Application` that is related to this `DataTableProductApplicationJoin`. */
   application?: Maybe<Application>;
-  /** Reads a single `DataTableProduct` that is related to this `DataTableProductApplicationJoin`. */
-  dataTableProduct?: Maybe<DataTableProduct>;
   /** An edge for our `DataTableProductApplicationJoin`. May be used by Relay 1. */
   dataTableProductApplicationJoinEdge?: Maybe<DataTableProductApplicationJoinsEdge>;
 };
@@ -38438,54 +42580,128 @@ export type UpdateDataTableProductApplicationJoinInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `updateDataTableProvinceByNodeId` mutation. */
-export type UpdateDataTableProvinceByNodeIdInput = {
+/** All input for the `updateDataTableProvisionalProductByNodeId` mutation. */
+export type UpdateDataTableProvisionalProductByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableProvince` to be updated. */
+  /** The globally unique `ID` which will identify a single `DataTableProvisionalProduct` to be updated. */
   nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `DataTableProvince` being updated. */
-  patch: DataTableProvincePatch;
+  /** An object where the defined keys will be set on the `DataTableProvisionalProduct` being updated. */
+  patch: DataTableProvisionalProductPatch;
 };
 
-/** Represents an update to a `DataTableProvince`. Fields that are set will be updated. */
-export type DataTableProvincePatch = {
-  id?: Maybe<Scalars['Int']>;
-  area?: Maybe<Scalars['String']>;
-  nome?: Maybe<Scalars['String']>;
-  codigo?: Maybe<Scalars['String']>;
-  capital?: Maybe<Scalars['String']>;
-  comunas?: Maybe<Scalars['String']>;
-  populacao?: Maybe<Scalars['String']>;
-  municipios?: Maybe<Scalars['String']>;
-  nameUppercase?: Maybe<Scalars['String']>;
-};
-
-/** The output of our update `DataTableProvince` mutation. */
-export type UpdateDataTableProvincePayload = {
-  __typename?: 'UpdateDataTableProvincePayload';
+/** The output of our update `DataTableProvisionalProduct` mutation. */
+export type UpdateDataTableProvisionalProductPayload = {
+  __typename?: 'UpdateDataTableProvisionalProductPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableProvince` that was updated by this mutation. */
-  dataTableProvince?: Maybe<DataTableProvince>;
+  /** The `DataTableProvisionalProduct` that was updated by this mutation. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableProvince`. May be used by Relay 1. */
-  dataTableProvinceEdge?: Maybe<DataTableProvincesEdge>;
+  /** An edge for our `DataTableProvisionalProduct`. May be used by Relay 1. */
+  dataTableProvisionalProductEdge?: Maybe<DataTableProvisionalProductsEdge>;
 };
 
 
-/** The output of our update `DataTableProvince` mutation. */
-export type UpdateDataTableProvincePayloadDataTableProvinceEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableProvincesOrderBy>>;
+/** The output of our update `DataTableProvisionalProduct` mutation. */
+export type UpdateDataTableProvisionalProductPayloadDataTableProvisionalProductEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductsOrderBy>>;
 };
 
-/** All input for the `updateDataTableProvince` mutation. */
-export type UpdateDataTableProvinceInput = {
+/** All input for the `updateDataTableProvisionalProduct` mutation. */
+export type UpdateDataTableProvisionalProductInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `DataTableProvince` being updated. */
-  patch: DataTableProvincePatch;
+  /** An object where the defined keys will be set on the `DataTableProvisionalProduct` being updated. */
+  patch: DataTableProvisionalProductPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableProvisionalProductApplicationJoinByNodeId` mutation. */
+export type UpdateDataTableProvisionalProductApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableProvisionalProductApplicationJoin` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableProvisionalProductApplicationJoin` being updated. */
+  patch: DataTableProvisionalProductApplicationJoinPatch;
+};
+
+/** The output of our update `DataTableProvisionalProductApplicationJoin` mutation. */
+export type UpdateDataTableProvisionalProductApplicationJoinPayload = {
+  __typename?: 'UpdateDataTableProvisionalProductApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableProvisionalProductApplicationJoin` that was updated by this mutation. */
+  dataTableProvisionalProductApplicationJoin?: Maybe<DataTableProvisionalProductApplicationJoin>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableProvisionalProduct` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
+  /** An edge for our `DataTableProvisionalProductApplicationJoin`. May be used by Relay 1. */
+  dataTableProvisionalProductApplicationJoinEdge?: Maybe<DataTableProvisionalProductApplicationJoinsEdge>;
+};
+
+
+/** The output of our update `DataTableProvisionalProductApplicationJoin` mutation. */
+export type UpdateDataTableProvisionalProductApplicationJoinPayloadDataTableProvisionalProductApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `updateDataTableProvisionalProductApplicationJoin` mutation. */
+export type UpdateDataTableProvisionalProductApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableProvisionalProductApplicationJoin` being updated. */
+  patch: DataTableProvisionalProductApplicationJoinPatch;
+  id: Scalars['Int'];
+};
+
+/** All input for the `updateDataTableScheduledChemicalByNodeId` mutation. */
+export type UpdateDataTableScheduledChemicalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableScheduledChemical` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `DataTableScheduledChemical` being updated. */
+  patch: DataTableScheduledChemicalPatch;
+};
+
+/** Represents an update to a `DataTableScheduledChemical`. Fields that are set will be updated. */
+export type DataTableScheduledChemicalPatch = {
+  id?: Maybe<Scalars['Int']>;
+  chemical?: Maybe<Scalars['String']>;
+  schedule?: Maybe<Scalars['String']>;
+};
+
+/** The output of our update `DataTableScheduledChemical` mutation. */
+export type UpdateDataTableScheduledChemicalPayload = {
+  __typename?: 'UpdateDataTableScheduledChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableScheduledChemical` that was updated by this mutation. */
+  dataTableScheduledChemical?: Maybe<DataTableScheduledChemical>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableScheduledChemical`. May be used by Relay 1. */
+  dataTableScheduledChemicalEdge?: Maybe<DataTableScheduledChemicalsEdge>;
+};
+
+
+/** The output of our update `DataTableScheduledChemical` mutation. */
+export type UpdateDataTableScheduledChemicalPayloadDataTableScheduledChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableScheduledChemicalsOrderBy>>;
+};
+
+/** All input for the `updateDataTableScheduledChemical` mutation. */
+export type UpdateDataTableScheduledChemicalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `DataTableScheduledChemical` being updated. */
+  patch: DataTableScheduledChemicalPatch;
   id: Scalars['Int'];
 };
 
@@ -38502,8 +42718,9 @@ export type UpdateDataTableStorageConditionByNodeIdInput = {
 /** Represents an update to a `DataTableStorageCondition`. Fields that are set will be updated. */
 export type DataTableStorageConditionPatch = {
   id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  portugueseName?: Maybe<Scalars['String']>;
+  code?: Maybe<Scalars['String']>;
+  longDescription?: Maybe<Scalars['String']>;
+  shortDescription?: Maybe<Scalars['String']>;
 };
 
 /** The output of our update `DataTableStorageCondition` mutation. */
@@ -38916,6 +43133,54 @@ export type UpdateFilterByCodeInput = {
   code: Scalars['String'];
 };
 
+/** All input for the `updateGrafanaDashboardImageByNodeId` mutation. */
+export type UpdateGrafanaDashboardImageByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GrafanaDashboardImage` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `GrafanaDashboardImage` being updated. */
+  patch: GrafanaDashboardImagePatch;
+};
+
+/** Represents an update to a `GrafanaDashboardImage`. Fields that are set will be updated. */
+export type GrafanaDashboardImagePatch = {
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  data?: Maybe<Scalars['String']>;
+  updatedDate?: Maybe<Scalars['Datetime']>;
+};
+
+/** The output of our update `GrafanaDashboardImage` mutation. */
+export type UpdateGrafanaDashboardImagePayload = {
+  __typename?: 'UpdateGrafanaDashboardImagePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrafanaDashboardImage` that was updated by this mutation. */
+  grafanaDashboardImage?: Maybe<GrafanaDashboardImage>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `GrafanaDashboardImage`. May be used by Relay 1. */
+  grafanaDashboardImageEdge?: Maybe<GrafanaDashboardImagesEdge>;
+};
+
+
+/** The output of our update `GrafanaDashboardImage` mutation. */
+export type UpdateGrafanaDashboardImagePayloadGrafanaDashboardImageEdgeArgs = {
+  orderBy?: Maybe<Array<GrafanaDashboardImagesOrderBy>>;
+};
+
+/** All input for the `updateGrafanaDashboardImage` mutation. */
+export type UpdateGrafanaDashboardImageInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `GrafanaDashboardImage` being updated. */
+  patch: GrafanaDashboardImagePatch;
+  id: Scalars['Int'];
+  name: Scalars['String'];
+};
+
 /** All input for the `updateNotificationByNodeId` mutation. */
 export type UpdateNotificationByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -39196,46 +43461,6 @@ export type UpdatePermissionPolicyByNameInput = {
   /** An object where the defined keys will be set on the `PermissionPolicy` being updated. */
   patch: PermissionPolicyPatch;
   name: Scalars['String'];
-};
-
-/** All input for the `updateProductApplicationJoinByNodeId` mutation. */
-export type UpdateProductApplicationJoinByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `ProductApplicationJoin` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `ProductApplicationJoin` being updated. */
-  patch: ProductApplicationJoinPatch;
-};
-
-/** The output of our update `ProductApplicationJoin` mutation. */
-export type UpdateProductApplicationJoinPayload = {
-  __typename?: 'UpdateProductApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `ProductApplicationJoin` that was updated by this mutation. */
-  productApplicationJoin?: Maybe<ProductApplicationJoin>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `ProductApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** An edge for our `ProductApplicationJoin`. May be used by Relay 1. */
-  productApplicationJoinEdge?: Maybe<ProductApplicationJoinsEdge>;
-};
-
-
-/** The output of our update `ProductApplicationJoin` mutation. */
-export type UpdateProductApplicationJoinPayloadProductApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<ProductApplicationJoinsOrderBy>>;
-};
-
-/** All input for the `updateProductApplicationJoin` mutation. */
-export type UpdateProductApplicationJoinInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `ProductApplicationJoin` being updated. */
-  patch: ProductApplicationJoinPatch;
-  id: Scalars['Int'];
 };
 
 /** All input for the `updateReviewByNodeId` mutation. */
@@ -40178,58 +44403,6 @@ export type UpdateUserOrganisationInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `updateUserOrganisationByUserIdAndOrganisationId` mutation. */
-export type UpdateUserOrganisationByUserIdAndOrganisationIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `UserOrganisation` being updated. */
-  patch: UserOrganisationPatch;
-  userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
-};
-
-/** All input for the `updateUserOrganisationApplicationJoinByNodeId` mutation. */
-export type UpdateUserOrganisationApplicationJoinByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `UserOrganisationApplicationJoin` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `UserOrganisationApplicationJoin` being updated. */
-  patch: UserOrganisationApplicationJoinPatch;
-};
-
-/** The output of our update `UserOrganisationApplicationJoin` mutation. */
-export type UpdateUserOrganisationApplicationJoinPayload = {
-  __typename?: 'UpdateUserOrganisationApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `UserOrganisationApplicationJoin` that was updated by this mutation. */
-  userOrganisationApplicationJoin?: Maybe<UserOrganisationApplicationJoin>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `UserOrganisationApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** Reads a single `UserOrganisation` that is related to this `UserOrganisationApplicationJoin`. */
-  userOrganisation?: Maybe<UserOrganisation>;
-  /** An edge for our `UserOrganisationApplicationJoin`. May be used by Relay 1. */
-  userOrganisationApplicationJoinEdge?: Maybe<UserOrganisationApplicationJoinsEdge>;
-};
-
-
-/** The output of our update `UserOrganisationApplicationJoin` mutation. */
-export type UpdateUserOrganisationApplicationJoinPayloadUserOrganisationApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
-};
-
-/** All input for the `updateUserOrganisationApplicationJoin` mutation. */
-export type UpdateUserOrganisationApplicationJoinInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `UserOrganisationApplicationJoin` being updated. */
-  patch: UserOrganisationApplicationJoinPatch;
-  id: Scalars['Int'];
-};
-
 /** All input for the `updateVerificationByNodeId` mutation. */
 export type UpdateVerificationByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -40534,6 +44707,53 @@ export type DeleteApplicationResponseInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `deleteApplicationReviewerActionByNodeId` mutation. */
+export type DeleteApplicationReviewerActionByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `ApplicationReviewerAction` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `ApplicationReviewerAction` mutation. */
+export type DeleteApplicationReviewerActionPayload = {
+  __typename?: 'DeleteApplicationReviewerActionPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `ApplicationReviewerAction` that was deleted by this mutation. */
+  applicationReviewerAction?: Maybe<ApplicationReviewerAction>;
+  deletedApplicationReviewerActionNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `User` that is related to this `ApplicationReviewerAction`. */
+  user?: Maybe<User>;
+  /** Reads a single `Application` that is related to this `ApplicationReviewerAction`. */
+  application?: Maybe<Application>;
+  /** An edge for our `ApplicationReviewerAction`. May be used by Relay 1. */
+  applicationReviewerActionEdge?: Maybe<ApplicationReviewerActionsEdge>;
+};
+
+
+/** The output of our delete `ApplicationReviewerAction` mutation. */
+export type DeleteApplicationReviewerActionPayloadApplicationReviewerActionEdgeArgs = {
+  orderBy?: Maybe<Array<ApplicationReviewerActionsOrderBy>>;
+};
+
+/** All input for the `deleteApplicationReviewerAction` mutation. */
+export type DeleteApplicationReviewerActionInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteApplicationReviewerActionByUserIdAndApplicationId` mutation. */
+export type DeleteApplicationReviewerActionByUserIdAndApplicationIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  userId: Scalars['Int'];
+  applicationId: Scalars['Int'];
+};
+
 /** All input for the `deleteApplicationStageHistoryByNodeId` mutation. */
 export type DeleteApplicationStageHistoryByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -40737,41 +44957,6 @@ export type DeleteDataTableByTableNameInput = {
   tableName: Scalars['String'];
 };
 
-/** All input for the `deleteDataTableManufacturingStepByNodeId` mutation. */
-export type DeleteDataTableManufacturingStepByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableManufacturingStep` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `DataTableManufacturingStep` mutation. */
-export type DeleteDataTableManufacturingStepPayload = {
-  __typename?: 'DeleteDataTableManufacturingStepPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStep` that was deleted by this mutation. */
-  dataTableManufacturingStep?: Maybe<DataTableManufacturingStep>;
-  deletedDataTableManufacturingStepNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStep`. May be used by Relay 1. */
-  dataTableManufacturingStepEdge?: Maybe<DataTableManufacturingStepsEdge>;
-};
-
-
-/** The output of our delete `DataTableManufacturingStep` mutation. */
-export type DeleteDataTableManufacturingStepPayloadDataTableManufacturingStepEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsOrderBy>>;
-};
-
-/** All input for the `deleteDataTableManufacturingStep` mutation. */
-export type DeleteDataTableManufacturingStepInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-};
-
 /** All input for the `deleteDataTableActiveIngredientByNodeId` mutation. */
 export type DeleteDataTableActiveIngredientByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -40947,41 +45132,6 @@ export type DeleteDataTableAtcCodeInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `deleteDataTableAtcTherapeuticCategoryByNodeId` mutation. */
-export type DeleteDataTableAtcTherapeuticCategoryByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableAtcTherapeuticCategory` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `DataTableAtcTherapeuticCategory` mutation. */
-export type DeleteDataTableAtcTherapeuticCategoryPayload = {
-  __typename?: 'DeleteDataTableAtcTherapeuticCategoryPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableAtcTherapeuticCategory` that was deleted by this mutation. */
-  dataTableAtcTherapeuticCategory?: Maybe<DataTableAtcTherapeuticCategory>;
-  deletedDataTableAtcTherapeuticCategoryNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableAtcTherapeuticCategory`. May be used by Relay 1. */
-  dataTableAtcTherapeuticCategoryEdge?: Maybe<DataTableAtcTherapeuticCategoriesEdge>;
-};
-
-
-/** The output of our delete `DataTableAtcTherapeuticCategory` mutation. */
-export type DeleteDataTableAtcTherapeuticCategoryPayloadDataTableAtcTherapeuticCategoryEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableAtcTherapeuticCategoriesOrderBy>>;
-};
-
-/** All input for the `deleteDataTableAtcTherapeuticCategory` mutation. */
-export type DeleteDataTableAtcTherapeuticCategoryInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-};
-
 /** All input for the `deleteDataTableContainerByNodeId` mutation. */
 export type DeleteDataTableContainerByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -41087,6 +45237,41 @@ export type DeleteDataTableDosageFormInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `deleteDataTableDosageFormGroupByNodeId` mutation. */
+export type DeleteDataTableDosageFormGroupByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableDosageFormGroup` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableDosageFormGroup` mutation. */
+export type DeleteDataTableDosageFormGroupPayload = {
+  __typename?: 'DeleteDataTableDosageFormGroupPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableDosageFormGroup` that was deleted by this mutation. */
+  dataTableDosageFormGroup?: Maybe<DataTableDosageFormGroup>;
+  deletedDataTableDosageFormGroupNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableDosageFormGroup`. May be used by Relay 1. */
+  dataTableDosageFormGroupEdge?: Maybe<DataTableDosageFormGroupsEdge>;
+};
+
+
+/** The output of our delete `DataTableDosageFormGroup` mutation. */
+export type DeleteDataTableDosageFormGroupPayloadDataTableDosageFormGroupEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableDosageFormGroupsOrderBy>>;
+};
+
+/** All input for the `deleteDataTableDosageFormGroup` mutation. */
+export type DeleteDataTableDosageFormGroupInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
 /** All input for the `deleteDataTableGenericIngredientByNodeId` mutation. */
 export type DeleteDataTableGenericIngredientByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -41117,76 +45302,6 @@ export type DeleteDataTableGenericIngredientPayloadDataTableGenericIngredientEdg
 
 /** All input for the `deleteDataTableGenericIngredient` mutation. */
 export type DeleteDataTableGenericIngredientInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-};
-
-/** All input for the `deleteDataTableIngredientsListByNodeId` mutation. */
-export type DeleteDataTableIngredientsListByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableIngredientsList` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `DataTableIngredientsList` mutation. */
-export type DeleteDataTableIngredientsListPayload = {
-  __typename?: 'DeleteDataTableIngredientsListPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableIngredientsList` that was deleted by this mutation. */
-  dataTableIngredientsList?: Maybe<DataTableIngredientsList>;
-  deletedDataTableIngredientsListNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableIngredientsList`. May be used by Relay 1. */
-  dataTableIngredientsListEdge?: Maybe<DataTableIngredientsListsEdge>;
-};
-
-
-/** The output of our delete `DataTableIngredientsList` mutation. */
-export type DeleteDataTableIngredientsListPayloadDataTableIngredientsListEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableIngredientsListsOrderBy>>;
-};
-
-/** All input for the `deleteDataTableIngredientsList` mutation. */
-export type DeleteDataTableIngredientsListInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-};
-
-/** All input for the `deleteDataTableInternationalDiallingPrefixByNodeId` mutation. */
-export type DeleteDataTableInternationalDiallingPrefixByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableInternationalDiallingPrefix` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `DataTableInternationalDiallingPrefix` mutation. */
-export type DeleteDataTableInternationalDiallingPrefixPayload = {
-  __typename?: 'DeleteDataTableInternationalDiallingPrefixPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableInternationalDiallingPrefix` that was deleted by this mutation. */
-  dataTableInternationalDiallingPrefix?: Maybe<DataTableInternationalDiallingPrefix>;
-  deletedDataTableInternationalDiallingPrefixNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** An edge for our `DataTableInternationalDiallingPrefix`. May be used by Relay 1. */
-  dataTableInternationalDiallingPrefixEdge?: Maybe<DataTableInternationalDiallingPrefixesEdge>;
-};
-
-
-/** The output of our delete `DataTableInternationalDiallingPrefix` mutation. */
-export type DeleteDataTableInternationalDiallingPrefixPayloadDataTableInternationalDiallingPrefixEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableInternationalDiallingPrefixesOrderBy>>;
-};
-
-/** All input for the `deleteDataTableInternationalDiallingPrefix` mutation. */
-export type DeleteDataTableInternationalDiallingPrefixInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
@@ -41227,36 +45342,332 @@ export type DeleteDataTableListOfSraInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `deleteDataTableManufacturingStepsSimplerByNodeId` mutation. */
-export type DeleteDataTableManufacturingStepsSimplerByNodeIdInput = {
+/** All input for the `deleteDataTableManufacturerByNodeId` mutation. */
+export type DeleteDataTableManufacturerByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableManufacturingStepsSimpler` to be deleted. */
+  /** The globally unique `ID` which will identify a single `DataTableManufacturer` to be deleted. */
   nodeId: Scalars['ID'];
 };
 
-/** The output of our delete `DataTableManufacturingStepsSimpler` mutation. */
-export type DeleteDataTableManufacturingStepsSimplerPayload = {
-  __typename?: 'DeleteDataTableManufacturingStepsSimplerPayload';
+/** The output of our delete `DataTableManufacturer` mutation. */
+export type DeleteDataTableManufacturerPayload = {
+  __typename?: 'DeleteDataTableManufacturerPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableManufacturingStepsSimpler` that was deleted by this mutation. */
-  dataTableManufacturingStepsSimpler?: Maybe<DataTableManufacturingStepsSimpler>;
-  deletedDataTableManufacturingStepsSimplerNodeId?: Maybe<Scalars['ID']>;
+  /** The `DataTableManufacturer` that was deleted by this mutation. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+  deletedDataTableManufacturerNodeId?: Maybe<Scalars['ID']>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableManufacturingStepsSimpler`. May be used by Relay 1. */
-  dataTableManufacturingStepsSimplerEdge?: Maybe<DataTableManufacturingStepsSimplersEdge>;
+  /** An edge for our `DataTableManufacturer`. May be used by Relay 1. */
+  dataTableManufacturerEdge?: Maybe<DataTableManufacturersEdge>;
 };
 
 
-/** The output of our delete `DataTableManufacturingStepsSimpler` mutation. */
-export type DeleteDataTableManufacturingStepsSimplerPayloadDataTableManufacturingStepsSimplerEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableManufacturingStepsSimplersOrderBy>>;
+/** The output of our delete `DataTableManufacturer` mutation. */
+export type DeleteDataTableManufacturerPayloadDataTableManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturersOrderBy>>;
 };
 
-/** All input for the `deleteDataTableManufacturingStepsSimpler` mutation. */
-export type DeleteDataTableManufacturingStepsSimplerInput = {
+/** All input for the `deleteDataTableManufacturer` mutation. */
+export type DeleteDataTableManufacturerInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTableManufacturerApplicationJoinByNodeId` mutation. */
+export type DeleteDataTableManufacturerApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableManufacturerApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerApplicationJoinPayload = {
+  __typename?: 'DeleteDataTableManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerApplicationJoin` that was deleted by this mutation. */
+  dataTableManufacturerApplicationJoin?: Maybe<DataTableManufacturerApplicationJoin>;
+  deletedDataTableManufacturerApplicationJoinNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturer` that is related to this `DataTableManufacturerApplicationJoin`. */
+  dataTableManufacturer?: Maybe<DataTableManufacturer>;
+  /** An edge for our `DataTableManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerApplicationJoinEdge?: Maybe<DataTableManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our delete `DataTableManufacturerApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerApplicationJoinPayloadDataTableManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `deleteDataTableManufacturerApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTableManufacturerRepresentativeByNodeId` mutation. */
+export type DeleteDataTableManufacturerRepresentativeByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerRepresentative` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableManufacturerRepresentative` mutation. */
+export type DeleteDataTableManufacturerRepresentativePayload = {
+  __typename?: 'DeleteDataTableManufacturerRepresentativePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentative` that was deleted by this mutation. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  deletedDataTableManufacturerRepresentativeNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableManufacturerRepresentative`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeEdge?: Maybe<DataTableManufacturerRepresentativesEdge>;
+};
+
+
+/** The output of our delete `DataTableManufacturerRepresentative` mutation. */
+export type DeleteDataTableManufacturerRepresentativePayloadDataTableManufacturerRepresentativeEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativesOrderBy>>;
+};
+
+/** All input for the `deleteDataTableManufacturerRepresentative` mutation. */
+export type DeleteDataTableManufacturerRepresentativeInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTableManufacturerRepresentativeApplicationJoinByNodeId` mutation. */
+export type DeleteDataTableManufacturerRepresentativeApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableManufacturerRepresentativeApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerRepresentativeApplicationJoinPayload = {
+  __typename?: 'DeleteDataTableManufacturerRepresentativeApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableManufacturerRepresentativeApplicationJoin` that was deleted by this mutation. */
+  dataTableManufacturerRepresentativeApplicationJoin?: Maybe<DataTableManufacturerRepresentativeApplicationJoin>;
+  deletedDataTableManufacturerRepresentativeApplicationJoinNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableManufacturerRepresentative` that is related to this `DataTableManufacturerRepresentativeApplicationJoin`. */
+  dataTableManufacturerRepresentative?: Maybe<DataTableManufacturerRepresentative>;
+  /** An edge for our `DataTableManufacturerRepresentativeApplicationJoin`. May be used by Relay 1. */
+  dataTableManufacturerRepresentativeApplicationJoinEdge?: Maybe<DataTableManufacturerRepresentativeApplicationJoinsEdge>;
+};
+
+
+/** The output of our delete `DataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerRepresentativeApplicationJoinPayloadDataTableManufacturerRepresentativeApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableManufacturerRepresentativeApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `deleteDataTableManufacturerRepresentativeApplicationJoin` mutation. */
+export type DeleteDataTableManufacturerRepresentativeApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTablePermitChemicalByNodeId` mutation. */
+export type DeleteDataTablePermitChemicalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePermitChemical` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTablePermitChemical` mutation. */
+export type DeleteDataTablePermitChemicalPayload = {
+  __typename?: 'DeleteDataTablePermitChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemical` that was deleted by this mutation. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  deletedDataTablePermitChemicalNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePermitChemical`. May be used by Relay 1. */
+  dataTablePermitChemicalEdge?: Maybe<DataTablePermitChemicalsEdge>;
+};
+
+
+/** The output of our delete `DataTablePermitChemical` mutation. */
+export type DeleteDataTablePermitChemicalPayloadDataTablePermitChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalsOrderBy>>;
+};
+
+/** All input for the `deleteDataTablePermitChemical` mutation. */
+export type DeleteDataTablePermitChemicalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTablePermitChemicalApplicationJoinByNodeId` mutation. */
+export type DeleteDataTablePermitChemicalApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePermitChemicalApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTablePermitChemicalApplicationJoin` mutation. */
+export type DeleteDataTablePermitChemicalApplicationJoinPayload = {
+  __typename?: 'DeleteDataTablePermitChemicalApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePermitChemicalApplicationJoin` that was deleted by this mutation. */
+  dataTablePermitChemicalApplicationJoin?: Maybe<DataTablePermitChemicalApplicationJoin>;
+  deletedDataTablePermitChemicalApplicationJoinNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePermitChemical` that is related to this `DataTablePermitChemicalApplicationJoin`. */
+  dataTablePermitChemical?: Maybe<DataTablePermitChemical>;
+  /** An edge for our `DataTablePermitChemicalApplicationJoin`. May be used by Relay 1. */
+  dataTablePermitChemicalApplicationJoinEdge?: Maybe<DataTablePermitChemicalApplicationJoinsEdge>;
+};
+
+
+/** The output of our delete `DataTablePermitChemicalApplicationJoin` mutation. */
+export type DeleteDataTablePermitChemicalApplicationJoinPayloadDataTablePermitChemicalApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePermitChemicalApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `deleteDataTablePermitChemicalApplicationJoin` mutation. */
+export type DeleteDataTablePermitChemicalApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTablePreRegisteredProductsProvisionalByNodeId` mutation. */
+export type DeleteDataTablePreRegisteredProductsProvisionalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePreRegisteredProductsProvisional` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTablePreRegisteredProductsProvisional` mutation. */
+export type DeleteDataTablePreRegisteredProductsProvisionalPayload = {
+  __typename?: 'DeleteDataTablePreRegisteredProductsProvisionalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePreRegisteredProductsProvisional` that was deleted by this mutation. */
+  dataTablePreRegisteredProductsProvisional?: Maybe<DataTablePreRegisteredProductsProvisional>;
+  deletedDataTablePreRegisteredProductsProvisionalNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePreRegisteredProductsProvisional`. May be used by Relay 1. */
+  dataTablePreRegisteredProductsProvisionalEdge?: Maybe<DataTablePreRegisteredProductsProvisionalsEdge>;
+};
+
+
+/** The output of our delete `DataTablePreRegisteredProductsProvisional` mutation. */
+export type DeleteDataTablePreRegisteredProductsProvisionalPayloadDataTablePreRegisteredProductsProvisionalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePreRegisteredProductsProvisionalsOrderBy>>;
+};
+
+/** All input for the `deleteDataTablePreRegisteredProductsProvisional` mutation. */
+export type DeleteDataTablePreRegisteredProductsProvisionalInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTablePrequalManufacturerByNodeId` mutation. */
+export type DeleteDataTablePrequalManufacturerByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePrequalManufacturer` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTablePrequalManufacturer` mutation. */
+export type DeleteDataTablePrequalManufacturerPayload = {
+  __typename?: 'DeleteDataTablePrequalManufacturerPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturer` that was deleted by this mutation. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  deletedDataTablePrequalManufacturerNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTablePrequalManufacturer`. May be used by Relay 1. */
+  dataTablePrequalManufacturerEdge?: Maybe<DataTablePrequalManufacturersEdge>;
+};
+
+
+/** The output of our delete `DataTablePrequalManufacturer` mutation. */
+export type DeleteDataTablePrequalManufacturerPayloadDataTablePrequalManufacturerEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturersOrderBy>>;
+};
+
+/** All input for the `deleteDataTablePrequalManufacturer` mutation. */
+export type DeleteDataTablePrequalManufacturerInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTablePrequalManufacturerApplicationJoinByNodeId` mutation. */
+export type DeleteDataTablePrequalManufacturerApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTablePrequalManufacturerApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type DeleteDataTablePrequalManufacturerApplicationJoinPayload = {
+  __typename?: 'DeleteDataTablePrequalManufacturerApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTablePrequalManufacturerApplicationJoin` that was deleted by this mutation. */
+  dataTablePrequalManufacturerApplicationJoin?: Maybe<DataTablePrequalManufacturerApplicationJoin>;
+  deletedDataTablePrequalManufacturerApplicationJoinNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTablePrequalManufacturer` that is related to this `DataTablePrequalManufacturerApplicationJoin`. */
+  dataTablePrequalManufacturer?: Maybe<DataTablePrequalManufacturer>;
+  /** An edge for our `DataTablePrequalManufacturerApplicationJoin`. May be used by Relay 1. */
+  dataTablePrequalManufacturerApplicationJoinEdge?: Maybe<DataTablePrequalManufacturerApplicationJoinsEdge>;
+};
+
+
+/** The output of our delete `DataTablePrequalManufacturerApplicationJoin` mutation. */
+export type DeleteDataTablePrequalManufacturerApplicationJoinPayloadDataTablePrequalManufacturerApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTablePrequalManufacturerApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `deleteDataTablePrequalManufacturerApplicationJoin` mutation. */
+export type DeleteDataTablePrequalManufacturerApplicationJoinInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
@@ -41352,8 +45763,6 @@ export type DeleteDataTableProductApplicationJoinPayload = {
   query?: Maybe<Query>;
   /** Reads a single `Application` that is related to this `DataTableProductApplicationJoin`. */
   application?: Maybe<Application>;
-  /** Reads a single `DataTableProduct` that is related to this `DataTableProductApplicationJoin`. */
-  dataTableProduct?: Maybe<DataTableProduct>;
   /** An edge for our `DataTableProductApplicationJoin`. May be used by Relay 1. */
   dataTableProductApplicationJoinEdge?: Maybe<DataTableProductApplicationJoinsEdge>;
 };
@@ -41371,36 +45780,110 @@ export type DeleteDataTableProductApplicationJoinInput = {
   id: Scalars['Int'];
 };
 
-/** All input for the `deleteDataTableProvinceByNodeId` mutation. */
-export type DeleteDataTableProvinceByNodeIdInput = {
+/** All input for the `deleteDataTableProvisionalProductByNodeId` mutation. */
+export type DeleteDataTableProvisionalProductByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `DataTableProvince` to be deleted. */
+  /** The globally unique `ID` which will identify a single `DataTableProvisionalProduct` to be deleted. */
   nodeId: Scalars['ID'];
 };
 
-/** The output of our delete `DataTableProvince` mutation. */
-export type DeleteDataTableProvincePayload = {
-  __typename?: 'DeleteDataTableProvincePayload';
+/** The output of our delete `DataTableProvisionalProduct` mutation. */
+export type DeleteDataTableProvisionalProductPayload = {
+  __typename?: 'DeleteDataTableProvisionalProductPayload';
   /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
   clientMutationId?: Maybe<Scalars['String']>;
-  /** The `DataTableProvince` that was deleted by this mutation. */
-  dataTableProvince?: Maybe<DataTableProvince>;
-  deletedDataTableProvinceNodeId?: Maybe<Scalars['ID']>;
+  /** The `DataTableProvisionalProduct` that was deleted by this mutation. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
+  deletedDataTableProvisionalProductNodeId?: Maybe<Scalars['ID']>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
-  /** An edge for our `DataTableProvince`. May be used by Relay 1. */
-  dataTableProvinceEdge?: Maybe<DataTableProvincesEdge>;
+  /** An edge for our `DataTableProvisionalProduct`. May be used by Relay 1. */
+  dataTableProvisionalProductEdge?: Maybe<DataTableProvisionalProductsEdge>;
 };
 
 
-/** The output of our delete `DataTableProvince` mutation. */
-export type DeleteDataTableProvincePayloadDataTableProvinceEdgeArgs = {
-  orderBy?: Maybe<Array<DataTableProvincesOrderBy>>;
+/** The output of our delete `DataTableProvisionalProduct` mutation. */
+export type DeleteDataTableProvisionalProductPayloadDataTableProvisionalProductEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductsOrderBy>>;
 };
 
-/** All input for the `deleteDataTableProvince` mutation. */
-export type DeleteDataTableProvinceInput = {
+/** All input for the `deleteDataTableProvisionalProduct` mutation. */
+export type DeleteDataTableProvisionalProductInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTableProvisionalProductApplicationJoinByNodeId` mutation. */
+export type DeleteDataTableProvisionalProductApplicationJoinByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableProvisionalProductApplicationJoin` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableProvisionalProductApplicationJoin` mutation. */
+export type DeleteDataTableProvisionalProductApplicationJoinPayload = {
+  __typename?: 'DeleteDataTableProvisionalProductApplicationJoinPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableProvisionalProductApplicationJoin` that was deleted by this mutation. */
+  dataTableProvisionalProductApplicationJoin?: Maybe<DataTableProvisionalProductApplicationJoin>;
+  deletedDataTableProvisionalProductApplicationJoinNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Application` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  application?: Maybe<Application>;
+  /** Reads a single `DataTableProvisionalProduct` that is related to this `DataTableProvisionalProductApplicationJoin`. */
+  dataTableProvisionalProduct?: Maybe<DataTableProvisionalProduct>;
+  /** An edge for our `DataTableProvisionalProductApplicationJoin`. May be used by Relay 1. */
+  dataTableProvisionalProductApplicationJoinEdge?: Maybe<DataTableProvisionalProductApplicationJoinsEdge>;
+};
+
+
+/** The output of our delete `DataTableProvisionalProductApplicationJoin` mutation. */
+export type DeleteDataTableProvisionalProductApplicationJoinPayloadDataTableProvisionalProductApplicationJoinEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableProvisionalProductApplicationJoinsOrderBy>>;
+};
+
+/** All input for the `deleteDataTableProvisionalProductApplicationJoin` mutation. */
+export type DeleteDataTableProvisionalProductApplicationJoinInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+};
+
+/** All input for the `deleteDataTableScheduledChemicalByNodeId` mutation. */
+export type DeleteDataTableScheduledChemicalByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `DataTableScheduledChemical` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `DataTableScheduledChemical` mutation. */
+export type DeleteDataTableScheduledChemicalPayload = {
+  __typename?: 'DeleteDataTableScheduledChemicalPayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `DataTableScheduledChemical` that was deleted by this mutation. */
+  dataTableScheduledChemical?: Maybe<DataTableScheduledChemical>;
+  deletedDataTableScheduledChemicalNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `DataTableScheduledChemical`. May be used by Relay 1. */
+  dataTableScheduledChemicalEdge?: Maybe<DataTableScheduledChemicalsEdge>;
+};
+
+
+/** The output of our delete `DataTableScheduledChemical` mutation. */
+export type DeleteDataTableScheduledChemicalPayloadDataTableScheduledChemicalEdgeArgs = {
+  orderBy?: Maybe<Array<DataTableScheduledChemicalsOrderBy>>;
+};
+
+/** All input for the `deleteDataTableScheduledChemical` mutation. */
+export type DeleteDataTableScheduledChemicalInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
@@ -41725,6 +46208,42 @@ export type DeleteFilterByCodeInput = {
   code: Scalars['String'];
 };
 
+/** All input for the `deleteGrafanaDashboardImageByNodeId` mutation. */
+export type DeleteGrafanaDashboardImageByNodeIdInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GrafanaDashboardImage` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** The output of our delete `GrafanaDashboardImage` mutation. */
+export type DeleteGrafanaDashboardImagePayload = {
+  __typename?: 'DeleteGrafanaDashboardImagePayload';
+  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrafanaDashboardImage` that was deleted by this mutation. */
+  grafanaDashboardImage?: Maybe<GrafanaDashboardImage>;
+  deletedGrafanaDashboardImageNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** An edge for our `GrafanaDashboardImage`. May be used by Relay 1. */
+  grafanaDashboardImageEdge?: Maybe<GrafanaDashboardImagesEdge>;
+};
+
+
+/** The output of our delete `GrafanaDashboardImage` mutation. */
+export type DeleteGrafanaDashboardImagePayloadGrafanaDashboardImageEdgeArgs = {
+  orderBy?: Maybe<Array<GrafanaDashboardImagesOrderBy>>;
+};
+
+/** All input for the `deleteGrafanaDashboardImage` mutation. */
+export type DeleteGrafanaDashboardImageInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+  name: Scalars['String'];
+};
+
 /** All input for the `deleteNotificationByNodeId` mutation. */
 export type DeleteNotificationByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -41979,43 +46498,6 @@ export type DeletePermissionPolicyByNameInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
   name: Scalars['String'];
-};
-
-/** All input for the `deleteProductApplicationJoinByNodeId` mutation. */
-export type DeleteProductApplicationJoinByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `ProductApplicationJoin` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `ProductApplicationJoin` mutation. */
-export type DeleteProductApplicationJoinPayload = {
-  __typename?: 'DeleteProductApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `ProductApplicationJoin` that was deleted by this mutation. */
-  productApplicationJoin?: Maybe<ProductApplicationJoin>;
-  deletedProductApplicationJoinNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `ProductApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** An edge for our `ProductApplicationJoin`. May be used by Relay 1. */
-  productApplicationJoinEdge?: Maybe<ProductApplicationJoinsEdge>;
-};
-
-
-/** The output of our delete `ProductApplicationJoin` mutation. */
-export type DeleteProductApplicationJoinPayloadProductApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<ProductApplicationJoinsOrderBy>>;
-};
-
-/** All input for the `deleteProductApplicationJoin` mutation. */
-export type DeleteProductApplicationJoinInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
 };
 
 /** All input for the `deleteReviewByNodeId` mutation. */
@@ -42870,53 +47352,6 @@ export type DeleteUserOrganisationPayloadUserOrganisationEdgeArgs = {
 
 /** All input for the `deleteUserOrganisation` mutation. */
 export type DeleteUserOrganisationInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-};
-
-/** All input for the `deleteUserOrganisationByUserIdAndOrganisationId` mutation. */
-export type DeleteUserOrganisationByUserIdAndOrganisationIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  userId: Scalars['Int'];
-  organisationId: Scalars['Int'];
-};
-
-/** All input for the `deleteUserOrganisationApplicationJoinByNodeId` mutation. */
-export type DeleteUserOrganisationApplicationJoinByNodeIdInput = {
-  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `UserOrganisationApplicationJoin` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** The output of our delete `UserOrganisationApplicationJoin` mutation. */
-export type DeleteUserOrganisationApplicationJoinPayload = {
-  __typename?: 'DeleteUserOrganisationApplicationJoinPayload';
-  /** The exact same `clientMutationId` that was provided in the mutation input, unchanged and unused. May be used by a client to track mutations. */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `UserOrganisationApplicationJoin` that was deleted by this mutation. */
-  userOrganisationApplicationJoin?: Maybe<UserOrganisationApplicationJoin>;
-  deletedUserOrganisationApplicationJoinNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Application` that is related to this `UserOrganisationApplicationJoin`. */
-  application?: Maybe<Application>;
-  /** Reads a single `UserOrganisation` that is related to this `UserOrganisationApplicationJoin`. */
-  userOrganisation?: Maybe<UserOrganisation>;
-  /** An edge for our `UserOrganisationApplicationJoin`. May be used by Relay 1. */
-  userOrganisationApplicationJoinEdge?: Maybe<UserOrganisationApplicationJoinsEdge>;
-};
-
-
-/** The output of our delete `UserOrganisationApplicationJoin` mutation. */
-export type DeleteUserOrganisationApplicationJoinPayloadUserOrganisationApplicationJoinEdgeArgs = {
-  orderBy?: Maybe<Array<UserOrganisationApplicationJoinsOrderBy>>;
-};
-
-/** All input for the `deleteUserOrganisationApplicationJoin` mutation. */
-export type DeleteUserOrganisationApplicationJoinInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
   clientMutationId?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
@@ -43975,6 +48410,7 @@ export type GetApplicationListQuery = (
   { __typename?: 'Query' }
   & { applicationList?: Maybe<(
     { __typename?: 'ApplicationListShapesConnection' }
+    & Pick<ApplicationListShapesConnection, 'totalCount'>
     & { nodes: Array<Maybe<(
       { __typename?: 'ApplicationListShape' }
       & Pick<ApplicationListShape, 'id' | 'serial' | 'name' | 'templateCode' | 'templateName' | 'applicant' | 'orgName' | 'stage' | 'stageColour' | 'status' | 'outcome' | 'lastActiveDate' | 'applicantDeadline' | 'reviewerAction' | 'assignerAction' | 'assigners' | 'reviewers'>
@@ -46498,6 +50934,7 @@ export const GetApplicationListDocument = gql`
       assigners
       reviewers
     }
+    totalCount
   }
   templates(condition: {status: AVAILABLE, code: $templateCode}) {
     nodes {

--- a/src/utils/graphql/queries/getApplicationsList.query.ts
+++ b/src/utils/graphql/queries/getApplicationsList.query.ts
@@ -35,6 +35,7 @@ export default gql`
         assigners
         reviewers
       }
+      totalCount
     }
     templates(condition: { status: AVAILABLE, code: $templateCode }) {
       nodes {

--- a/src/utils/hooks/useListApplications.tsx
+++ b/src/utils/hooks/useListApplications.tsx
@@ -21,8 +21,7 @@ const useListApplications = (
   const [applications, setApplications] = useState<ApplicationListShape[]>([])
   // Manually keep track of loading state, due to interval between loading application
   // and loading counts that causes flicker
-  const [isLoadingCount, setIsLoadingCount] = useState(true)
-  const [templateType, setTemplateType] = useState<TemplateType>()
+  // const [isLoadingCount, setIsLoadingCount] = useState(true)
   const [error, setError] = useState('')
   const { updateQuery } = useRouter()
   const {
@@ -60,14 +59,14 @@ const useListApplications = (
     fetchPolicy: 'network-only',
   })
 
-  const [getListCount, { data: countData }] = useGetFilteredApplicationCountLazyQuery({
-    fetchPolicy: 'network-only',
-    onCompleted: () => setIsLoadingCount(false),
-  })
+  // const [getListCount, { data: countData }] = useGetFilteredApplicationCountLazyQuery({
+  //   fetchPolicy: 'network-only',
+  //   onCompleted: () => setIsLoadingCount(false),
+  // })
 
   useEffect(() => {
     if (loading) {
-      setIsLoadingCount(true)
+      // setIsLoadingCount(true)
       setApplications([])
       return
     }
@@ -75,11 +74,6 @@ const useListApplications = (
     if (applicationsError) {
       setError(applicationsError.message)
       return
-    }
-
-    if (data?.templates?.nodes && data?.templates?.nodes.length > 0) {
-      const { code, name, namePlural } = data?.templates?.nodes?.[0] as TemplateType
-      setTemplateType({ code, name, namePlural })
     }
 
     if (data?.applicationList) {
@@ -91,13 +85,16 @@ const useListApplications = (
       // And small compromise for the simplicity
       if (applicationsList.length === 0 && pageNumber !== 1) {
         updateQuery({ page: 1 })
-      } else {
-        getListCount({
-          variables: { filter: filters, userId: currentUser?.userId as number },
-        })
       }
+      //  else {
+      //   getListCount({
+      //     variables: { filter: filters, userId: currentUser?.userId as number },
+      //   })
+      // }
     }
   }, [applicationsError, loading])
+
+  const templateType = data?.templates?.nodes?.[0]
 
   return {
     error,
@@ -105,7 +102,7 @@ const useListApplications = (
     refetch,
     templateType,
     applications,
-    applicationCount: !isLoadingCount ? countData?.applicationList?.totalCount ?? null : null,
+    applicationCount: data?.applicationList?.totalCount ?? null,
   }
 }
 

--- a/src/utils/hooks/useListApplications.tsx
+++ b/src/utils/hooks/useListApplications.tsx
@@ -7,9 +7,8 @@ import {
   useGetApplicationListQuery,
   ApplicationListShape,
   ApplicationListShapesOrderBy,
-  useGetFilteredApplicationCountLazyQuery,
 } from '../../utils/generated/graphql'
-import { BasicStringObject, TemplateType } from '../types'
+import { BasicStringObject } from '../types'
 import { useUserState } from '../../contexts/UserState'
 import { useGetFilterDefinitions } from '../helpers/list/useGetFilterDefinitions'
 
@@ -19,9 +18,6 @@ const useListApplications = (
 ) => {
   const FILTER_DEFINITIONS = useGetFilterDefinitions()
   const [applications, setApplications] = useState<ApplicationListShape[]>([])
-  // Manually keep track of loading state, due to interval between loading application
-  // and loading counts that causes flicker
-  // const [isLoadingCount, setIsLoadingCount] = useState(true)
   const [error, setError] = useState('')
   const { updateQuery } = useRouter()
   const {
@@ -59,11 +55,6 @@ const useListApplications = (
     fetchPolicy: 'network-only',
   })
 
-  // const [getListCount, { data: countData }] = useGetFilteredApplicationCountLazyQuery({
-  //   fetchPolicy: 'network-only',
-  //   onCompleted: () => setIsLoadingCount(false),
-  // })
-
   useEffect(() => {
     if (loading) {
       // setIsLoadingCount(true)
@@ -86,11 +77,6 @@ const useListApplications = (
       if (applicationsList.length === 0 && pageNumber !== 1) {
         updateQuery({ page: 1 })
       }
-      //  else {
-      //   getListCount({
-      //     variables: { filter: filters, userId: currentUser?.userId as number },
-      //   })
-      // }
     }
   }, [applicationsError, loading])
 

--- a/src/utils/hooks/useListTemplates.tsx
+++ b/src/utils/hooks/useListTemplates.tsx
@@ -30,14 +30,14 @@ const useListTemplates = (templatePermissions: TemplatePermissions, isLoading: b
     fetchPolicy: 'cache-and-network',
   })
 
-  const templateData = emptyTemplateData
+  const templatesData = emptyTemplateData
 
   if (data?.templates?.nodes) {
     const filteredTemplates = (data?.templates?.nodes || []).filter(
       (template) => templatePermissions[String(template?.code)]
     ) as Template[]
     if (filteredTemplates.length > 0) {
-      templateData.templates = filteredTemplates
+      templatesData.templates = filteredTemplates
         .map((template) => convertFromTemplateToTemplateDetails(template, templatePermissions))
         .sort((a, b) => {
           if (a.templateCategory === b.templateCategory) {
@@ -51,14 +51,14 @@ const useListTemplates = (templatePermissions: TemplatePermissions, isLoading: b
           return (b.templateCategory.priority ?? 0) - (a.templateCategory.priority ?? 0)
         })
 
-      templateData.templatesByCategory = getTemplatesByCategory(templateData.templates)
+      templatesData.templatesByCategory = getTemplatesByCategory(templatesData.templates)
     }
   }
 
   return {
     error: error?.message ?? '',
     loading: loading && !data,
-    templatesData: templateData,
+    templatesData,
   }
 }
 


### PR DESCRIPTION
Front-end changes for back-end https://github.com/msupply-foundation/conforma-server/pull/1106

Main improvement was to get the cache working using [`cache-and-network` policy](https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy). The reason we hadn't been able to get this working in the past is that we were checking for `loading` from Apollo hook and rendering a Loading component. However, when using this policy, Apollo returns `loading:true` while it's doing its background query, so we would be displaying the loader rather than the cached result. Solution is to only show the loader if `loading: true && !data`. `data` is populated immediately with the cached version if it exists, so we can display it immediately.

See review comments for further improvements.