### PR TITLE
#1547 Better validation before progressing to next page or summary

### DIFF
--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Container, Dropdown, Icon, Loader } from 'semantic-ui-react'
+import { Button, Container, Dropdown, Loader } from 'semantic-ui-react'
 import {
   MethodRevalidate,
   MethodToCallProps,
@@ -33,7 +33,7 @@ const Navigation: React.FC<NavigationProps> = ({
   const { push } = useRouter()
   const { isMobile } = useViewport()
   const {
-    state: { elementCurrentlyProcessing },
+    state: { elementsCurrentlyProcessing },
   } = useFormElementUpdateTracker()
   const [navigateToIfAllOk, setNavigateToIfAllOk] = useState<
     null | 'summary' | 'nextPage' | string
@@ -56,7 +56,7 @@ const Navigation: React.FC<NavigationProps> = ({
     current.pageNumber + 1 > currentSectionDetails.totalPages && nextSection == null
 
   useEffect(() => {
-    if (elementCurrentlyProcessing.size > 0 || !navigateToIfAllOk) return
+    if (elementsCurrentlyProcessing.size > 0 || !navigateToIfAllOk) return
 
     switch (navigateToIfAllOk) {
       case 'summary': {
@@ -120,7 +120,7 @@ const Navigation: React.FC<NavigationProps> = ({
         )
       }
     }
-  }, [elementCurrentlyProcessing, navigateToIfAllOk])
+  }, [elementsCurrentlyProcessing, navigateToIfAllOk])
 
   const getPreviousSectionPage = (): SectionAndPage => {
     const { sectionCode, pageNumber } = current
@@ -187,7 +187,7 @@ const Navigation: React.FC<NavigationProps> = ({
     value: details.code,
   }))
 
-  const showLoader = isValidating || (elementCurrentlyProcessing.size > 0 && !!navigateToIfAllOk)
+  const showLoader = isValidating || (elementsCurrentlyProcessing.size > 0 && !!navigateToIfAllOk)
 
   return (
     <Container>

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button, Container, Dropdown, Icon, Loader } from 'semantic-ui-react'
 import {
   MethodRevalidate,
@@ -10,6 +10,7 @@ import {
 import { useLanguageProvider } from '../../contexts/Localisation'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { useViewport } from '../../contexts/ViewportState'
+import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
 
 interface NavigationProps {
   current: SectionAndPage
@@ -31,6 +32,11 @@ const Navigation: React.FC<NavigationProps> = ({
   const { t } = useLanguageProvider()
   const { push } = useRouter()
   const { isMobile } = useViewport()
+  const {
+    state: { elementCurrentlyProcessing },
+  } = useFormElementUpdateTracker()
+  const [navigateToIfAllOk, setNavigateToIfAllOk] = useState<false | string>(false)
+  const [buttonClicked, setButtonClicked] = useState(false)
 
   const currentSectionDetails = sections[current.sectionCode].details
 
@@ -47,6 +53,21 @@ const Navigation: React.FC<NavigationProps> = ({
   const isFirstPage = current.pageNumber - 1 === 0 && previousSection == null
   const isLastPage =
     current.pageNumber + 1 > currentSectionDetails.totalPages && nextSection == null
+
+  useEffect(() => {
+    if (elementCurrentlyProcessing.size > 0 || !navigateToIfAllOk) return
+
+    requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
+      if (firstStrictInvalidPage) {
+        setStrictSectionPage(firstStrictInvalidPage)
+        sendToPage(firstStrictInvalidPage)
+        setNavigateToIfAllOk(false)
+      } else {
+        push(navigateToIfAllOk)
+        setNavigateToIfAllOk(false)
+      }
+    })
+  }, [elementCurrentlyProcessing, navigateToIfAllOk])
 
   const getPreviousSectionPage = (): SectionAndPage => {
     const { sectionCode, pageNumber } = current
@@ -137,12 +158,13 @@ const Navigation: React.FC<NavigationProps> = ({
   }
 
   const summaryButtonHandler = () => {
-    requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
-      if (firstStrictInvalidPage) {
-        setStrictSectionPage(firstStrictInvalidPage)
-        sendToPage(firstStrictInvalidPage)
-      } else push(`/application/${serialNumber}/summary`)
-    })
+    setNavigateToIfAllOk(`/application/${serialNumber}/summary`)
+    // requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
+    //   if (firstStrictInvalidPage) {
+    //     setStrictSectionPage(firstStrictInvalidPage)
+    //     sendToPage(firstStrictInvalidPage)
+    //   } else push(`/application/${serialNumber}/summary`)
+    // })
   }
 
   const sectionOptions = Object.values(sections).map(({ details }) => ({
@@ -150,6 +172,8 @@ const Navigation: React.FC<NavigationProps> = ({
     text: details.title,
     value: details.code,
   }))
+
+  const showLoader = isValidating || (elementCurrentlyProcessing.size > 0 && !!navigateToIfAllOk)
 
   return (
     <Container>
@@ -170,11 +194,11 @@ const Navigation: React.FC<NavigationProps> = ({
           <Button
             primary
             inverted={isValidating}
-            disabled={isValidating}
+            disabled={showLoader}
             onClick={summaryButtonHandler}
           >
-            {isValidating ? t('BUTTON_VALIDATING') : t('BUTTON_SUMMARY')}
-            {isValidating && <Loader active inline size="tiny" />}
+            {showLoader ? t('BUTTON_VALIDATING') : t('BUTTON_SUMMARY')}
+            {showLoader && <Loader active inline size="tiny" />}
           </Button>
         </div>
         {isMobile && sectionOptions.length > 1 && (

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -21,11 +21,19 @@ interface ContextFormElementUpdateTrackerState {
   // if still waiting for element to update (i.e. it's still in focus, then it will be set to 'infinity')
   // if no elements were updated, it will be set to 0
   latestChangedElementUpdateTimestamp: number
+  // This refers to elements that are either:
+  // - having their parameters re-evaluated
+  // - saving to server
+  // We want to make sure the user can't move ahead while these are in progress,
+  // otherwise we can end up with invalid or inconsistent responses slipping
+  // through
+  elementCurrentlyProcessing: Set<string>
 }
 
 const contextStateDefault: ContextFormElementUpdateTrackerState = {
   elementsUpdateState: {},
   latestChangedElementUpdateTimestamp: 0,
+  elementCurrentlyProcessing: new Set(),
 }
 
 const calculateLatestChangedTimestamp = (elementsUpdateState: {
@@ -34,7 +42,7 @@ const calculateLatestChangedTimestamp = (elementsUpdateState: {
   Object.values(elementsUpdateState).reduce((latestUpdateTimestamp, singleElementState) => {
     if (latestUpdateTimestamp === Infinity) return Infinity
     const { enteredSequence, updatedSequence, changedTimestamp } = singleElementState
-    // Element is in focus still when entered sequence is higher then updated seqeunce, using sequence to accomodate plugins like password
+    // Element is in focus still when entered sequence is higher then updated sequence, using sequence to accommodate plugins like password
     // which have two fields for the same element, and there is a race condition when second field entered
     // occurs before first field exit (because exit is triggered after mutation)
     if (enteredSequence > updatedSequence) return Infinity
@@ -57,6 +65,14 @@ export type UpdateAction =
       elementCode: string
       textValue: string
       previousValue: string
+    }
+  | {
+      type: 'elementProcessing'
+      elementCode: string
+    }
+  | {
+      type: 'elementDoneProcessing'
+      elementCode: string
     }
 
 type FormElementUpdateTrackerProps = { children: React.ReactNode }
@@ -86,6 +102,7 @@ const reducer: Reducer = (state, action) => {
             enteredTextValue: action.textValue,
           },
         },
+        elementCurrentlyProcessing: state.elementCurrentlyProcessing,
       }
 
       return newState
@@ -131,8 +148,23 @@ const reducer: Reducer = (state, action) => {
       const newState: ContextFormElementUpdateTrackerState = {
         latestChangedElementUpdateTimestamp,
         elementsUpdateState: newElementsUpdateState,
+        elementCurrentlyProcessing: state.elementCurrentlyProcessing,
       }
 
+      return newState
+    }
+    case 'elementProcessing': {
+      const { elementCode } = action
+      const elementCurrentlyProcessing = new Set(state.elementCurrentlyProcessing)
+      elementCurrentlyProcessing.add(elementCode)
+      const newState = { ...state, elementCurrentlyProcessing }
+      return newState
+    }
+    case 'elementDoneProcessing': {
+      const { elementCode } = action
+      const elementCurrentlyProcessing = new Set(state.elementCurrentlyProcessing)
+      elementCurrentlyProcessing.delete(elementCode)
+      const newState = { ...state, elementCurrentlyProcessing }
       return newState
     }
     default:

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -27,13 +27,13 @@ interface ContextFormElementUpdateTrackerState {
   // We want to make sure the user can't move ahead while these are in progress,
   // otherwise we can end up with invalid or inconsistent responses slipping
   // through
-  elementCurrentlyProcessing: Set<string>
+  elementsCurrentlyProcessing: Set<string>
 }
 
 const contextStateDefault: ContextFormElementUpdateTrackerState = {
   elementsUpdateState: {},
   latestChangedElementUpdateTimestamp: 0,
-  elementCurrentlyProcessing: new Set(),
+  elementsCurrentlyProcessing: new Set(),
 }
 
 const calculateLatestChangedTimestamp = (elementsUpdateState: {
@@ -102,7 +102,7 @@ const reducer: Reducer = (state, action) => {
             enteredTextValue: action.textValue,
           },
         },
-        elementCurrentlyProcessing: state.elementCurrentlyProcessing,
+        elementsCurrentlyProcessing: state.elementsCurrentlyProcessing,
       }
 
       return newState
@@ -148,23 +148,23 @@ const reducer: Reducer = (state, action) => {
       const newState: ContextFormElementUpdateTrackerState = {
         latestChangedElementUpdateTimestamp,
         elementsUpdateState: newElementsUpdateState,
-        elementCurrentlyProcessing: state.elementCurrentlyProcessing,
+        elementsCurrentlyProcessing: state.elementsCurrentlyProcessing,
       }
 
       return newState
     }
     case 'elementProcessing': {
       const { elementCode } = action
-      const elementCurrentlyProcessing = new Set(state.elementCurrentlyProcessing)
-      elementCurrentlyProcessing.add(elementCode)
-      const newState = { ...state, elementCurrentlyProcessing }
+      const elementsCurrentlyProcessing = new Set(state.elementsCurrentlyProcessing)
+      elementsCurrentlyProcessing.add(elementCode)
+      const newState = { ...state, elementsCurrentlyProcessing }
       return newState
     }
     case 'elementDoneProcessing': {
       const { elementCode } = action
-      const elementCurrentlyProcessing = new Set(state.elementCurrentlyProcessing)
-      elementCurrentlyProcessing.delete(elementCode)
-      const newState = { ...state, elementCurrentlyProcessing }
+      const elementsCurrentlyProcessing = new Set(state.elementsCurrentlyProcessing)
+      elementsCurrentlyProcessing.delete(elementCode)
+      const newState = { ...state, elementsCurrentlyProcessing }
       return newState
     }
     default:

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -74,8 +74,13 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   // Update dynamic parameters when responses change
   useEffect(() => {
     const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
-    Object.entries(parameterExpressions).forEach(([field, expression]) => {
-      evaluateExpression(expression as EvaluatorNode, {
+    setUpdateTrackerState({
+      type: 'elementProcessing',
+      elementCode: code,
+    })
+
+    const result = Object.entries(parameterExpressions).map(([field, expression]) => {
+      return evaluateExpression(expression as EvaluatorNode, {
         objects: { responses: allResponses, currentUser, applicationData, functions },
         APIfetch: fetch,
         graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
@@ -89,6 +94,12 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
         }
       })
     })
+    Promise.all(result).then(() =>
+      setUpdateTrackerState({
+        type: 'elementDoneProcessing',
+        elementCode: code,
+      })
+    )
   }, [allResponses])
 
   useEffect(() => {
@@ -117,6 +128,10 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   }
 
   const onSave = async (response: ResponseFull) => {
+    setUpdateTrackerState({
+      type: 'elementProcessing',
+      elementCode: code,
+    })
     if (!response?.customValidation) {
       // Validate and Save response -- generic
       const validationResult: ValidationState = await onUpdate(response?.text)
@@ -167,6 +182,10 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       elementCode: code,
       textValue: textValue || '',
       previousValue: currentResponse?.text || '',
+    })
+    setUpdateTrackerState({
+      type: 'elementDoneProcessing',
+      elementCode: code,
     })
   }
 


### PR DESCRIPTION
Fix #1547 

Adds an extra property to `FormElementUpdateTrackerState` to hold a record of any elements currently "processing", i.e either re-evaluating properties, or saving. 

Navigation can no longer progress until this value also reports nothing in progress.